### PR TITLE
Correctly resume syncing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,12 @@ fn main() {
 
     info!("Handling STATUS message");
     let uncrypted_body = utils::read_message(&mut stream, &mut ingress_mac, &mut ingress_aes);
-    current_hash = eth::parse_status_message(uncrypted_body[1..].to_vec());
+    let their_current_hash = eth::parse_status_message(uncrypted_body[1..].to_vec());
+
+    // If we do't have blocks in the database we use the best one 
+    if current_hash.len() == 0 {
+        current_hash = their_current_hash;
+    }
 
     /********************
      *


### PR DESCRIPTION
This PR fix the current hash choice. If the database already have a hash you don't want to use the best hash from the node as a point of start for syncig.