### PR TITLE
feat: use in status the correct version

### DIFF
--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -166,6 +166,7 @@ fn main() {
 
     // let status = message::create_status_message(&genesis_hash, &genesis_hash, &head_td, &fork_id, &network_id);
     let status = eth::create_status_message(
+        &68,
         &genesis_hash,
         &genesis_hash,
         &head_td,

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,7 @@ fn main() {
                 version = capability.version;
             }
         }
-    }   
+    }
 
     /******************
      *

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     // Read cli args for network value
     let network_arg: String = env::args()
         .nth(1)
-        .expect("expecting a network (ethereum_rinkeby, ethereum_goerli, ethereum_sepolia, ethereum_mainnet or binance_mainnet).");
+        .expect("expecting a network (ethereum_ropsten, ethereum_rinkeby, ethereum_goerli, ethereum_sepolia, ethereum_mainnet or binance_mainnet).");
     let network = networks::Network::find(network_arg.as_str()).unwrap();
 
     // Load config values from the config file
@@ -181,9 +181,17 @@ fn main() {
 
     // Should be HELLO
     assert_eq!(0x80, uncrypted_body[0]);
-    let payload = rlp::decode::<types::HelloMessage>(&uncrypted_body[1..]).unwrap();
+    let hello_message = rlp::decode::<types::HelloMessage>(&uncrypted_body[1..]).unwrap();
 
-    dbg!(&payload);
+    // We need to find the highest eth version it supports
+    let mut version = 0;
+    for capability in hello_message.capabilities {
+        if capability.name.0.to_string() == "eth" {
+            if capability.version > version {
+                version = capability.version;
+            }
+        }
+    }   
 
     /******************
      *
@@ -209,6 +217,7 @@ fn main() {
     let network_id = network.network_id;
 
     let status = eth::create_status_message(
+        &version,
         &genesis_hash,
         &genesis_hash,
         &head_td,

--- a/src/protocols/eth.rs
+++ b/src/protocols/eth.rs
@@ -6,6 +6,7 @@ use crate::types::{Block, Transaction};
 
 // Create status message following the ETH protocol
 pub fn create_status_message(
+    version: &usize,
     genesis_hash: &Vec<u8>,
     head_hash: &Vec<u8>,
     head_td: &u64,
@@ -15,8 +16,7 @@ pub fn create_status_message(
     let mut s = rlp::RlpStream::new();
     s.begin_unbounded_list();
     // Protocol version
-    // TODO: find the highest matching protocol
-    s.append(&68_u8);
+    s.append(version);
     // network Id
     s.append(network_id);
     // head Td


### PR DESCRIPTION
We are now filling the version in the STATUS message with the correct version and not the harcoded 68 for eth.