### PR TITLE
fix: v value should be saved as BIGINT

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -38,3 +38,37 @@ We can't get all the from addresses because we need to recover from signature.
 ```
 CREATE MATERIALIZED VIEW contracts AS SELECT c.address, COUNT(DISTINCT t.txid) FROM ethereum_mainnet.transactions t RIGHT JOIN ethereum_mainnet.contracts c ON c.address = t.toaddress GROUP BY c.address;
 ```
+
+## Troubelshooting
+
+### Rospten transaction index
+
+There is apparently 2 transactions with the same txid in Rospten but that are included in different blocks.
+
+```
+blockchains=# SELECT * FROM ethereum_ropsten.transactions WHERE txid = '\x1abfd69255ca1791da6a00c729707348d63670221aaacbac5160dbb234430e7a'
+blockchains-# ;
+	                                txid                                |                               block                                | nonce | gasprice | gaslimit |                 toaddress                 
+ | value |                                                                    data                                                                    |  v   |                                 r                   
+               |                                 s                                  |                                                                                                                              
+                                                      raw                                                                                                                                                          
+                           
+--------------------------------------------------------------------+--------------------------------------------------------------------+-------+----------+----------+-------------------------------------------
+-+-------+--------------------------------------------------------------------------------------------------------------------------------------------+------+-----------------------------------------------------
+---------------+--------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+---------------------------
+ \x1abfd69255ca1791da6a00c729707348d63670221aaacbac5160dbb234430e7a | \x5efe8c021dd98b0b834d1377f596a156a58c710af92153639ac0be10039c5e38 |   991 |        0 |    29817 | \x0908376b760421303711e9c397ec897897258f3a
+ | \x    | \x095ea7b3000000000000000000000000d61144557dfb4953c20c376affa6b4a3780c99d1000000000000000000000000000000000000000000000000e92596fd62900000 | \x31 | \x40d755b31bff08bf0db5df9cf957636ab07171403705e8c350
+b3e448f1f95713 | \x74cdf82ad3993075dd35fd1a3f4c4146058ecf4d82f122d9abacd1a6f9e273d2 | \x02f8b1038203df8459682f008459682f0e827479940908376b760421303711e9c397ec897897258f3a80b844095ea7b3000000000000000000000000d61
+144557dfb4953c20c376affa6b4a3780c99d1000000000000000000000000000000000000000000000000e92596fd62900000c001a040d755b31bff08bf0db5df9cf957636ab07171403705e8c350b3e448f1f95713a074cdf82ad3993075dd35fd1a3f4c4146058ecf
+4d82f122d9abacd1a6f9e273d2
+ \x1abfd69255ca1791da6a00c729707348d63670221aaacbac5160dbb234430e7a | \xc48beccf35e6f73bc1e79c60cb19c77eccff6b964a3a8bcd179c6e8b181ccded |   991 |        0 |    29817 | \x0908376b760421303711e9c397ec897897258f3a
+ | \x    | \x095ea7b3000000000000000000000000d61144557dfb4953c20c376affa6b4a3780c99d1000000000000000000000000000000000000000000000000e92596fd62900000 | \x31 | \x40d755b31bff08bf0db5df9cf957636ab07171403705e8c350
+b3e448f1f95713 | \x74cdf82ad3993075dd35fd1a3f4c4146058ecf4d82f122d9abacd1a6f9e273d2 | \x02f8b1038203df8459682f008459682f0e827479940908376b760421303711e9c397ec897897258f3a80b844095ea7b3000000000000000000000000d61
+144557dfb4953c20c376affa6b4a3780c99d1000000000000000000000000000000000000000000000000e92596fd62900000c001a040d755b31bff08bf0db5df9cf957636ab07171403705e8c350b3e448f1f95713a074cdf82ad3993075dd35fd1a3f4c4146058ecf
+4d82f122d9abacd1a6f9e273d2
+(2 rows)
+```
+
+In order to create index we need to remove one...

--- a/src/database.rs
+++ b/src/database.rs
@@ -22,7 +22,7 @@ pub fn create_tables(schema_name: &String, postgres_client: &mut Client) {
         toaddress BYTEA NOT NULL,
         value BYTEA NOT NULL,
         data BYTEA NOT NULL,
-        v BYTEA NOT NULL,
+        v BIGINT NOT NULL,
         r BYTEA NOT NULL,
         s BYTEA NOT NULL,
         raw BYTEA

--- a/src/message.rs
+++ b/src/message.rs
@@ -32,7 +32,7 @@ pub fn parse_transaction(payload: Vec<u8>) -> Transaction {
                 let to: Vec<u8> = t.at(4).unwrap().as_val().unwrap();
                 let value: Vec<u8> = t.at(5).unwrap().as_val().unwrap();
                 let data: Vec<u8> = t.at(6).unwrap().as_val().unwrap();
-                let v: u32 = t.at(8).unwrap().as_val().unwrap();
+                let v: i64 = t.at(8).unwrap().as_val().unwrap();
                 let r: Vec<u8> = t.at(9).unwrap().as_val().unwrap();
                 let s: Vec<u8> = t.at(10).unwrap().as_val().unwrap();
 
@@ -65,7 +65,7 @@ pub fn parse_transaction(payload: Vec<u8>) -> Transaction {
                 let to: Vec<u8> = t.at(5).unwrap().as_val().unwrap();
                 let value: Vec<u8> = t.at(6).unwrap().as_val().unwrap();
                 let data: Vec<u8> = t.at(7).unwrap().as_val().unwrap();
-                let v: u32 = t.at(9).unwrap().as_val().unwrap();
+                let v: i64 = t.at(9).unwrap().as_val().unwrap();
                 let r: Vec<u8> = t.at(10).unwrap().as_val().unwrap();
                 let s: Vec<u8> = t.at(11).unwrap().as_val().unwrap();
 
@@ -102,7 +102,7 @@ pub fn parse_transaction(payload: Vec<u8>) -> Transaction {
                 // let access_list: Vec<u8> = t.at(8).unwrap().as_val().unwrap();
                 // let max_fee_per_blob_gas: Vec<u8> = t.at(9).unwrap().as_val().unwrap();
                 // let blob_versioned_hashes: Vec<u8> = t.at(10).unwrap().as_val().unwrap();
-                let v: u32 = t.at(11).unwrap().as_val().unwrap();
+                let v: i64 = t.at(11).unwrap().as_val().unwrap();
                 let r: Vec<u8> = t.at(12).unwrap().as_val().unwrap();
                 let s: Vec<u8> = t.at(13).unwrap().as_val().unwrap();
 
@@ -138,7 +138,7 @@ pub fn parse_transaction(payload: Vec<u8>) -> Transaction {
     let to: Vec<u8> = transaction.at(3).unwrap().as_val().unwrap();
     let value: Vec<u8> = transaction.at(4).unwrap().as_val().unwrap();
     let data: Vec<u8> = transaction.at(5).unwrap().as_val().unwrap();
-    let v: u32 = transaction.at(6).unwrap().as_val().unwrap();
+    let v: i64 = transaction.at(6).unwrap().as_val().unwrap();
     let r: Vec<u8> = transaction.at(7).unwrap().as_val().unwrap();
     let s: Vec<u8> = transaction.at(8).unwrap().as_val().unwrap();
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -32,7 +32,7 @@ pub fn parse_transaction(payload: Vec<u8>) -> Transaction {
                 let to: Vec<u8> = t.at(4).unwrap().as_val().unwrap();
                 let value: Vec<u8> = t.at(5).unwrap().as_val().unwrap();
                 let data: Vec<u8> = t.at(6).unwrap().as_val().unwrap();
-                let v: i64 = t.at(8).unwrap().as_val().unwrap();
+                let v: u64 = t.at(8).unwrap().as_val().unwrap();
                 let r: Vec<u8> = t.at(9).unwrap().as_val().unwrap();
                 let s: Vec<u8> = t.at(10).unwrap().as_val().unwrap();
 
@@ -65,7 +65,7 @@ pub fn parse_transaction(payload: Vec<u8>) -> Transaction {
                 let to: Vec<u8> = t.at(5).unwrap().as_val().unwrap();
                 let value: Vec<u8> = t.at(6).unwrap().as_val().unwrap();
                 let data: Vec<u8> = t.at(7).unwrap().as_val().unwrap();
-                let v: i64 = t.at(9).unwrap().as_val().unwrap();
+                let v: u64 = t.at(9).unwrap().as_val().unwrap();
                 let r: Vec<u8> = t.at(10).unwrap().as_val().unwrap();
                 let s: Vec<u8> = t.at(11).unwrap().as_val().unwrap();
 
@@ -102,7 +102,7 @@ pub fn parse_transaction(payload: Vec<u8>) -> Transaction {
                 // let access_list: Vec<u8> = t.at(8).unwrap().as_val().unwrap();
                 // let max_fee_per_blob_gas: Vec<u8> = t.at(9).unwrap().as_val().unwrap();
                 // let blob_versioned_hashes: Vec<u8> = t.at(10).unwrap().as_val().unwrap();
-                let v: i64 = t.at(11).unwrap().as_val().unwrap();
+                let v: u64 = t.at(11).unwrap().as_val().unwrap();
                 let r: Vec<u8> = t.at(12).unwrap().as_val().unwrap();
                 let s: Vec<u8> = t.at(13).unwrap().as_val().unwrap();
 
@@ -138,7 +138,7 @@ pub fn parse_transaction(payload: Vec<u8>) -> Transaction {
     let to: Vec<u8> = transaction.at(3).unwrap().as_val().unwrap();
     let value: Vec<u8> = transaction.at(4).unwrap().as_val().unwrap();
     let data: Vec<u8> = transaction.at(5).unwrap().as_val().unwrap();
-    let v: i64 = transaction.at(6).unwrap().as_val().unwrap();
+    let v: u64 = transaction.at(6).unwrap().as_val().unwrap();
     let r: Vec<u8> = transaction.at(7).unwrap().as_val().unwrap();
     let s: Vec<u8> = transaction.at(8).unwrap().as_val().unwrap();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,7 +88,7 @@ pub struct Transaction {
     // lets save it as raw bytes
     pub value: Vec<u8>,
     pub data: Vec<u8>,
-    pub v: u32,
+    pub v: u64,
     pub r: Vec<u8>,
     pub s: Vec<u8>,
     pub raw: Vec<u8>,


### PR DESCRIPTION
We changed the v value to be be saved as an integer but we didn't update the database. Also changed the v value to be a `i64` because in new transaction type it is mixed with chainID (e.g v = chainID * 2 + 35 + {0,1}).

See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#specification