### PR TITLE
feat: calculate CREATE contract address and add it to the dabatase

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -95,7 +95,7 @@ pub fn save_blocks(
             
             // if "to" adddress is empty, calculates the transaction address
             if t.to.is_empty() {
-                info!("Transaction address calculated");
+                info!("Calculating contract address");
                 let tx_address: Vec <u8> = utils::calculate_tx_addr(&t.from, &t.nonce);
                 let tmp = format!(
                     "\\\\x{};\\\\x{}\n",

--- a/src/database.rs
+++ b/src/database.rs
@@ -92,7 +92,7 @@ pub fn save_blocks(
                 hex::encode(&t.r),
                 hex::encode(&t.s),
             );
-            
+
             // if "to" adddress is empty, calculates the transaction address
             if t.to.is_empty() {
                 info!("Calculating contract address");
@@ -127,7 +127,9 @@ pub fn save_blocks(
     let mut contract_writer = transaction
         .copy_in(format!("COPY {}.contracts FROM stdin (DELIMITER ';')", schema_name).as_str())
         .unwrap();
-    contract_writer.write_all(contracts_string.as_bytes()).unwrap();
+    contract_writer
+        .write_all(contracts_string.as_bytes())
+        .unwrap();
     contract_writer.finish().unwrap();
 
     for txs in transactions_strings {

--- a/src/database.rs
+++ b/src/database.rs
@@ -98,7 +98,7 @@ pub fn save_blocks(
                 info!("Transaction address calculated");
                 let tx_address: Vec <u8> = utils::calculate_tx_addr(&t.from, &t.nonce);
                 let tmp = format!(
-                    "\\\\{}x;\\\\x{}\n",
+                    "\\\\x{};\\\\x{}\n",
                 hex::encode(&t.txid),
                 hex::encode(&tx_address));
                 contracts_string.push_str(&tmp);

--- a/src/main.rs
+++ b/src/main.rs
@@ -462,7 +462,7 @@ fn main() {
 
             // need to wait for database thread to finish
             database_handle.join().unwrap();
-            
+
             break;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,7 @@ fn main() {
     // Create a simple streaming channel (limited buffer of 4 batch of 1024 blocks to avoid filling ram)
     let (tx, rx) = sync_channel(4);
 
-    let _thread_handle = thread::spawn(move || {
+    let database_handle = thread::spawn(move || {
         info!("Starting database thread");
 
         // Connect to database
@@ -459,6 +459,10 @@ fn main() {
 
         if current_height == 0 {
             info!("Data fully synced");
+
+            // need to wait for database thread to finish
+            database_handle.join().unwrap();
+            
             break;
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -550,7 +550,7 @@ mod tests {
     fn calculate_tx() {
         let sender: Vec<u8> = hex::decode("bcB8DA04C3A6A6E92da829C305ba523e0ba3e804").unwrap();
         let nonce: u32 = 0;
-        let contract_address = calculate_tx_addr(sender, nonce);
+        let contract_address = calculate_tx_addr(&sender, &nonce);
         assert_eq!(
             hex::encode(contract_address),
             "7c4ed2ec55cfc474fa0249db61c0145d3280b914"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -399,11 +399,11 @@ pub fn read_message(
     return uncrypted_body;
 }
 
-pub fn calculate_tx_addr(sender: Vec<u8>, nonce: u32) -> Vec<u8> {
+pub fn calculate_tx_addr(sender: &Vec<u8>, nonce: &u32) -> Vec<u8> {
     let mut rlp_encoded = RlpStream::new();
     rlp_encoded.begin_unbounded_list();
-    rlp_encoded.append(&sender);
-    rlp_encoded.append(&nonce);
+    rlp_encoded.append(sender);
+    rlp_encoded.append(nonce);
     rlp_encoded.finalize_unbounded_list();
 
     let mut hasher = Keccak256::new();


### PR DESCRIPTION
With this PR we calculate and save the information related to contract creation. Unfortunately it only support CREATE kind of contract creation. CREATE2 required to execute the transactions in an EVM.