### PR TITLE
fix: warning for deprecated functions

### DIFF
--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -139,7 +139,7 @@ fn main() {
 
     // Should be HELLO
     assert_eq!(0x80, uncrypted_body[0]);
-    let payload = rlp::decode::<types::HelloMessage>(&uncrypted_body[1..]).unwrap();
+    let _payload = rlp::decode::<types::HelloMessage>(&uncrypted_body[1..]).unwrap();
 
     /******************
      *

--- a/examples/rpc.rs
+++ b/examples/rpc.rs
@@ -113,7 +113,7 @@ fn main() {
      ******************/
 
     let remote_data = [shared_mac_data, &payload].concat();
-    let (mut ingress_aes, mut ingress_mac, mut egress_aes, mut egress_mac) = utils::setup_frame(
+    let (mut ingress_aes, mut ingress_mac, egress_aes, egress_mac) = utils::setup_frame(
         remote_nonce,
         nonce,
         ephemeral_shared_secret,

--- a/src/message.rs
+++ b/src/message.rs
@@ -502,7 +502,7 @@ mod tests {
 
         let recid = secp256k1::ecdsa::RecoveryId::from_i32(v as i32).unwrap();
 
-        let msg = secp256k1::Message::from_slice(&digest).unwrap();
+        let msg = secp256k1::Message::from_digest_slice(&digest).unwrap();
         let sig = secp256k1::ecdsa::RecoverableSignature::from_compact(&sig_data, recid).unwrap();
 
         let _pubkey = secp256k1::SECP256K1.recover_ecdsa(&msg, &sig).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -161,7 +161,7 @@ pub fn create_auth_eip8(
     let ephemeral_signing_key = secp256k1::SecretKey::from_slice(&ephemeral_privkey).unwrap();
     let (recid, sig) = secp256k1::SECP256K1
         .sign_ecdsa_recoverable(
-            &secp256k1::Message::from_slice(&msg_hash).unwrap(),
+            &secp256k1::Message::from_digest_slice(&msg_hash).unwrap(),
             &ephemeral_signing_key,
         )
         .serialize_compact();


### PR DESCRIPTION
Editing some deprecated functions from "from_slice" to "from_digest_slice" because of warnings when running