### PR TITLE
fix: update binance forkid and get finalized block at first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Blocks per second: 13 (average)
 
 Blocks per second: 128 (average)
 
+## Troubleshooting
+
+### Erigon 2.58 node incomplete block body
+
+When connecting to an erigon node it seems there is some issue with devp2p for version `erigon/v2.58.2-125509e4/linux-amd64/go1.22.1`. It provides us with an incomplete block body message. The missing bytes lead to Rlp decoding error.
+
 ## License
 
 Do What The Fuck You Want To Public License

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,11 +270,9 @@ fn main() {
         );
     }
 
-
     // If we do't have blocks in the database we use the best one
     if current_hash.len() == 0 {
         current_hash = their_current_hash;
-
 
         /******************
          *
@@ -309,7 +307,6 @@ fn main() {
 
         // update block hash
         current_hash = block_headers.last().unwrap().parent_hash.to_vec();
-
     }
 
     /********************

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -38,7 +38,7 @@ impl Network {
             158, 177, 213, 24, 150, 158, 171, 82, 157, 217, 184, 140, 26,
         ],
         head_td: 10790000,
-        fork_id: [0x70cc14e2, 0],
+        fork_id: [0xf9843abf, 0],
         network_id: 0x05,
     };
 
@@ -71,7 +71,7 @@ impl Network {
             147, 203, 102, 93, 182, 42, 47, 59, 2, 210, 213, 123, 91,
         ],
         head_td: 585970,
-        fork_id: [0x3f2e9ae4, 0x4f1a00],
+        fork_id: [0x48fa7b05, 0],
         network_id: 0x38,
     };
 

--- a/src/protocols/eth.rs
+++ b/src/protocols/eth.rs
@@ -45,8 +45,6 @@ pub fn parse_status_message(payload: Vec<u8>) -> Vec<u8> {
     let mut dec = snap::raw::Decoder::new();
     let message = dec.decompress_vec(&payload).unwrap();
 
-    dbg!(hex::encode(&message));
-
     let r = rlp::Rlp::new(&message);
     assert!(r.is_list());
 

--- a/src/protocols/eth.rs
+++ b/src/protocols/eth.rs
@@ -142,6 +142,7 @@ pub fn parse_block_headers(payload: Vec<u8>) -> Vec<Block> {
     for i in 0..count {
         let block_header = block_headers.at(i).unwrap().as_raw();
         let block = util_parse_block_header(block_header.to_vec());
+        
         headers.push(block);
     }
 
@@ -187,7 +188,7 @@ pub fn parse_block_bodies(payload: Vec<u8>) -> Vec<(Vec<Transaction>, Vec<Block>
     for i in 0..count {
         let block_body = block_bodies.at(i).unwrap();
         assert!(block_body.is_list());
-
+        
         let transactions = block_body.at(0).unwrap();
         let count_tx = transactions.item_count().unwrap();
         let ommers = block_body.at(1).unwrap();

--- a/src/protocols/eth.rs
+++ b/src/protocols/eth.rs
@@ -142,7 +142,7 @@ pub fn parse_block_headers(payload: Vec<u8>) -> Vec<Block> {
     for i in 0..count {
         let block_header = block_headers.at(i).unwrap().as_raw();
         let block = util_parse_block_header(block_header.to_vec());
-        
+
         headers.push(block);
     }
 
@@ -188,7 +188,7 @@ pub fn parse_block_bodies(payload: Vec<u8>) -> Vec<(Vec<Transaction>, Vec<Block>
     for i in 0..count {
         let block_body = block_bodies.at(i).unwrap();
         assert!(block_body.is_list());
-        
+
         let transactions = block_body.at(0).unwrap();
         let count_tx = transactions.item_count().unwrap();
         let ommers = block_body.at(1).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -383,14 +383,15 @@ pub fn read_message(
 
     // we have this loop to be sure we have received the complete payload
     while body.len() < body_size {
-        // trace!(
-        //     "Incomplete message body waiting for the rest... ({})",
-        //     body.len()
-        // );
         let mut buf: Vec<u8> = vec![0; body_size - body.len()];
         let l = stream.read(&mut buf).unwrap();
 
         body.extend(&buf[0..l]);
+        trace!(
+            "Incomplete message body waiting for the rest... ({}/{})",
+            body.len(),
+            body_size,
+        );
         thread::sleep(Duration::from_millis(READ_MESSAGE_TIME_MS));
     }
 


### PR DESCRIPTION
The fork id is actually `0x48fa7b05`.

We also now get the blocks that have been finalized at first run. So 1024 blocks after the highest block hash in the status message.