### PR TITLE
feat: throw an error when receiving disctonnect message to exit the app

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -378,6 +378,15 @@ fn main() {
                         &thread_egress_aes,
                     );
                 }
+
+                if code == 1 {
+                    // Received a disconnect message
+                    let mut dec = snap::raw::Decoder::new();
+                    let message = dec.decompress_vec(&uncrypted_body[1..].to_vec()).unwrap();
+
+                    panic!("Disconnected ! {}", hex::encode(&message))
+                }
+
                 continue;
             }
 


### PR DESCRIPTION
When receiving a Disconnect message we now panic to exit the process with an error. It allows when using docker to restart the container and restart the indexing process.