### PR TITLE
fix: withdrawals are not available in pre-merge network

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -300,15 +300,12 @@ fn main() {
                 if code == 4 {
                     break;
                 }
-            } else {
-                dbg!(hex::encode(uncrypted_body));
             }
         }
 
         assert_eq!(code, 4);
 
         let block_headers = eth::parse_block_headers(uncrypted_body[1..].to_vec());
-        dbg!(&block_headers.last().unwrap().number);
 
         // update block hash
         current_hash = block_headers.last().unwrap().parent_hash.to_vec();

--- a/src/protocols/eth.rs
+++ b/src/protocols/eth.rs
@@ -1,3 +1,4 @@
+use rlp::Rlp;
 use sha3::{Digest, Keccak256};
 
 use super::constants::BASE_PROTOCOL_OFFSET;
@@ -179,6 +180,9 @@ pub fn parse_block_bodies(
     let r = rlp::Rlp::new(&message);
     assert!(r.is_list());
 
+    // empty list used for backward compatibility with withdrawals (pre-merge network)
+    let empty_list_bytes = vec![0xc0];
+
     // let req_id: usize = r.at(0).unwrap().as_val().unwrap();
     let block_bodies = r.at(1).unwrap();
 
@@ -193,7 +197,7 @@ pub fn parse_block_bodies(
         let count_tx = transactions.item_count().unwrap();
         let ommers = block_body.at(1).unwrap();
         let count_om = ommers.item_count().unwrap();
-        let withdrawals = block_body.at(2).unwrap();
+        let withdrawals = block_body.at(2).unwrap_or(rlp::Rlp::new(&empty_list_bytes)); // for backward compatibility (like when you are indexing pre-merge)
         let count_wd = withdrawals.item_count().unwrap();
 
         trace!("Transactions count : {}", count_tx);


### PR DESCRIPTION
Withdrawals are not present in pre-merge network so we add a fallback.