### PR TITLE
refactor: remove the queue size configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ethereum P2P indexer
 
-This project is an indexer for Ethereum and Ethereum forks. It takes advantage of the ETH (Ethereum Wire Protocol) to fetch blocks and transactions through P2P messages. This saves a lot of space and the need to maintain a node to get data. It is also significantly faster than the solution using JSON-RPC.
+This project is an indexer for Ethereum and Ethereum forks. It takes advantage of the ETH (Ethereum Wire Protocol) to fetch blocks and transactions through P2P messages. This saves a lot of space and the need to maintain a node to get data. It is also significantly faster than the solutions using JSON-RPC.
 
 In its current state, the indexer takes 48h to index mainnet from scratch.
 
@@ -45,8 +45,6 @@ ip = "127.0.0.1"
 port = 30303
 remote_id = "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
-[indexer]
-queue_size = 4
 ```
 
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,9 +4,6 @@ user = "postgres"
 password = "wow"
 dbname = "blockchains"
 
-[indexer]
-queue_size = 4
-
 # Mainnet
 [[peers]]
 ip = "127.0.0.1"

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -20,15 +20,9 @@ pub struct Peer {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct IndexerConfig {
-    pub queue_size: u32,
-}
-
-#[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     pub database: DatabaseConfig,
     pub peers: Vec<Peer>,
-    pub indexer: IndexerConfig,
 }
 
 pub fn read_config() -> Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,8 +105,8 @@ fn main() {
      *
      ********************/
 
-    // Creates the desired number of streaming channels (1024 blocks batches) (configurable in the config.toml file according to RAM capacity)
-    let (tx, rx) = sync_channel(config.indexer.queue_size.try_into().unwrap());
+    // Create a queue with a maximum of 102400 blocks (100 * 1024 = 102400 blocks). We query blocks by batch of 1024 blocks.
+    let (tx, rx) = sync_channel(100);
 
     let database_handle = thread::spawn(move || {
         info!("Starting database thread");


### PR DESCRIPTION
## Summary 

We removed the `queue_size` configuration in favor of a maximum 100 queue size value. It removes configuration overhead. And since the indexer is faster so the queue never filled anymore. Saving into the database is faster than receiving the blocks.

## What changed

- Remove `queue_size` configuration
- Updated the docs to reflect the simplified configuration