### PR TITLE
feat: exit on loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,14 @@ use std::env;
 use std::error;
 use std::net::SocketAddr;
 use std::net::TcpStream;
-use std::process;
 use std::str::FromStr;
 use std::sync::mpsc::SyncSender;
 use std::sync::mpsc::{channel, sync_channel};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::thread;
+use std::thread::{self, sleep};
 use std::time::Duration;
+use std::time::SystemTime;
 
 use eth_prototype::eth;
 use eth_prototype::types::{Block, Transaction, Withdrawal};
@@ -509,12 +509,31 @@ fn run(
         if reverse {
             *current_hash = block_headers.last().unwrap().parent_hash.to_vec();
         } else {
-            if current_hash.as_slice() == block_headers.last().unwrap().hash.as_slice() {
-                warn!("Last block is our current block");
+            if block_headers.len() == 0 {
+                warn!("No block founds");
                 return Err("No new blocks".into());
             }
 
-            *current_hash = block_headers.last().unwrap().hash.to_vec();
+            let last_block = block_headers.last().unwrap();
+
+            // Verify if the block has ben created less than 15 seconds ago. Blocks are being created every 15 seconds.
+            if SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as u32
+                - last_block.time
+                < 15
+            {
+                trace!("We have the latest created block. Waiting 15 seconds.");
+                sleep(Duration::from_secs(15));
+            } else {
+                if current_hash.as_slice() == last_block.hash.as_slice() {
+                    warn!("Last block is our current block");
+                    return Err("No new blocks".into());
+                }
+            }
+
+            *current_hash = last_block.hash.to_vec();
         }
 
         /******************


### PR DESCRIPTION
## Summary

This PR add a way to detect if we are stuck in a loop. Sometimes node don't have the rest of the chain so we need to connect to another node. We added a check to verify if the blocks headers return is either empty or the same as our current one.

In addition there is a check that compare the current time with the block to timestamp to determine if the block has been recently created. In the case the block has been created during the last 15 seconds. We wait 15 seconds so the next block can be created.

## What changed

* A check to verify we are not stuck in a loop
* Determine if the block has been created in the last 15 seconds, meaning we have the lastest block and we can wait 15 seconds that's the next one is created