### PR TITLE
feat: allow fetching blocks from multiple peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "sha3 0.10.8",
  "snap",
  "tokio",
+ "tokio-postgres",
  "toml",
  "tx-from-scratch",
  "web3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,7 @@ dependencies = [
  "serde_json",
  "sha3 0.10.8",
  "snap",
+ "tokio",
  "toml",
  "tx-from-scratch",
  "web3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ sha3 = "0.10.8"
 secp256k1 = { version = "0.28.1", features = ["recovery", "global-context", "rand-std", "hashes"] }
 snap = "1.1.0"
 postgres = { version = "0.19.9" }
+tokio-postgres = { version = "0.7" }
 primitive-types = { version = "0.13.1", features = ["impl-rlp"] }
 log = "0.4.22"
 env_logger = "0.11.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 num = "0.4.3"
 chrono = "0.4.39"
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 devp2p = { git = "https://github.com/rllola/devp2p" }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -4,8 +4,6 @@ use secp256k1::SecretKey;
 use std::error;
 use std::net::SocketAddr;
 use std::str::FromStr;
-use std::sync::Arc;
-use std::sync::Mutex;
 use std::time::Duration;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::Receiver;
@@ -13,12 +11,10 @@ use tokio::task::JoinHandle;
 
 use crate::configs::Peer;
 use crate::eth;
-use crate::mac;
 use crate::message;
 use crate::networks;
 use crate::types;
 use crate::utils;
-use crate::utils::Aes256Ctr64BE;
 
 pub struct Connection {
     pub handle: JoinHandle<()>,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,306 @@
+use rand_core::RngCore;
+use secp256k1::rand;
+use secp256k1::SecretKey;
+use std::error;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc::Receiver;
+use tokio::task::JoinHandle;
+
+use crate::configs::Peer;
+use crate::eth;
+use crate::mac;
+use crate::message;
+use crate::networks;
+use crate::types;
+use crate::utils;
+use crate::utils::Aes256Ctr64BE;
+
+pub struct Connection {
+    pub handle: JoinHandle<()>,
+    pub rx_tcp: Receiver<Vec<u8>>,
+    pub tx_write: tokio::sync::mpsc::Sender<Vec<u8>>,
+    pub eth_protocol_version: u32,
+    latest_blockhash: Vec<u8>,
+}
+
+impl Connection {
+    // latest_blockhash getter
+    pub fn latest_blockhash(&self) -> &Vec<u8> {
+        &self.latest_blockhash
+    }
+
+    pub async fn connect(
+        peer: Peer,
+        network: networks::Network,
+    ) -> Result<Self, Box<dyn error::Error + Send + Sync>> {
+        let addr = SocketAddr::from_str(&format!("{}:{}", peer.ip, peer.port))?;
+
+        let mut stream =
+            tokio::time::timeout(Duration::from_secs(3), TcpStream::connect(addr)).await??;
+        stream.set_nodelay(true)?;
+
+        let private_key = SecretKey::new(&mut rand::thread_rng())
+            .secret_bytes()
+            .to_vec();
+        let mut nonce = vec![0; 32];
+        rand::thread_rng().fill_bytes(&mut nonce);
+        let ephemeral_privkey = SecretKey::new(&mut rand::thread_rng())
+            .secret_bytes()
+            .to_vec();
+        let pad = vec![0; 100]; // should be generated randomly but we don't really care
+
+        info!("Creating EIP8 Auth message");
+        let init_msg = utils::create_auth_eip8(
+            &peer.remote_id,
+            &private_key,
+            &nonce,
+            &ephemeral_privkey,
+            &pad,
+        );
+
+        // send the message
+        info!("Sending EIP8 Auth message");
+        utils::send_eip8_auth_message(&init_msg, &mut stream).await?;
+
+        info!("waiting for answer... (ACK message)");
+        let (payload, shared_mac_data) = utils::read_ack_message(&mut stream).await?;
+
+        info!("ACK message received");
+        info!("Received Ack");
+        if payload[0] != 0x04 {
+            return Err("Didn't received ACK when expecting it".into());
+        }
+
+        let (_remote_public_key, remote_nonce, ephemeral_shared_secret) =
+            utils::handle_ack_message(&payload, &shared_mac_data, &private_key, &ephemeral_privkey);
+
+        let remote_data = [shared_mac_data, payload].concat();
+        let (mut ingress_aes, mut ingress_mac, mut egress_aes, mut egress_mac) = utils::setup_frame(
+            remote_nonce,
+            nonce,
+            ephemeral_shared_secret,
+            remote_data,
+            init_msg,
+        );
+
+        info!("Frame setup done !");
+
+        info!("Received Ack, waiting for Header");
+
+        let uncrypted_body =
+            utils::read_message(&mut stream, &mut ingress_mac, &mut ingress_aes).await?;
+
+        if uncrypted_body[0] == 0x01 {
+            warn!("Disconnect message : {}", hex::encode(&uncrypted_body));
+
+            return Err("Disconnected peer".into());
+        }
+
+        // Should be HELLO
+        assert_eq!(0x80, uncrypted_body[0]);
+        let hello_message = message::parse_hello_message(uncrypted_body[1..].to_vec());
+
+        info!(
+            "HelloMessage {}",
+            serde_json::to_string(&hello_message).unwrap()
+        );
+
+        // We need to find the highest eth version it supports
+        let mut version = 0;
+        for capability in &hello_message.capabilities {
+            if capability.0.to_string() == "eth" {
+                if capability.1 > version {
+                    version = capability.1;
+                }
+            }
+        }
+
+        info!("Sending HELLO message");
+        let secp = secp256k1::Secp256k1::new();
+        let private_key = secp256k1::SecretKey::from_slice(&private_key).unwrap();
+        let hello_message = types::HelloMessage {
+            protocol_version: message::BASE_PROTOCOL_VERSION,
+            client: String::from("deadbrain corp."),
+            capabilities: vec![("eth".into(), 67), ("eth".into(), 68), ("eth".into(), 69)],
+            port: 0,
+            id: secp256k1::PublicKey::from_secret_key(&secp, &private_key).serialize_uncompressed()
+                [1..]
+                .to_vec(),
+        };
+        let hello = message::create_hello_message(hello_message);
+        utils::send_message(hello, &mut stream, &mut egress_mac, &mut egress_aes).await?;
+
+        info!("Sending STATUS message");
+
+        let payload: Vec<u8>;
+        if version == 69 {
+            let status = eth::Status69 {
+                version,
+                network_id: network.network_id,
+                genesis: network.genesis_hash.to_vec(),
+                fork_id: (network.fork_id[0].to_be_bytes().to_vec(), 0),
+                earliest: 0,
+                latest: 0,
+                latest_hash: network.genesis_hash.to_vec(),
+            };
+            payload = eth::create_eth69_status_message(status);
+        } else {
+            let status = eth::Status {
+                version,
+                network_id: network.network_id,
+                td: network
+                    .head_td
+                    .to_be_bytes()
+                    .iter()
+                    .skip_while(|x| **x == 0)
+                    .map(|x| *x)
+                    .collect(), // Maybe I should just have change the status type. But this is needed for now to remove the zeroes at the begining
+                blockhash: network.genesis_hash.to_vec(),
+                genesis: network.genesis_hash.to_vec(),
+                fork_id: (network.fork_id[0].to_be_bytes().to_vec(), 0),
+            };
+            payload = eth::create_status_message(status);
+        }
+        utils::send_message(payload, &mut stream, &mut egress_mac, &mut egress_aes).await?;
+
+        info!("Handling STATUS message");
+        let uncrypted_body =
+            utils::read_message(&mut stream, &mut ingress_mac, &mut ingress_aes).await?;
+        if uncrypted_body[0] == 0x01 {
+            warn!("Disconnect message : {}", hex::encode(&uncrypted_body));
+
+            return Err("Disconnected peer".into());
+        }
+
+        let their_blockhash: Vec<u8>;
+        if version == 69 {
+            let their_status =
+                eth::parse_eth69_status_message(uncrypted_body[1..].to_vec()).unwrap();
+
+            if their_status.fork_id.0 != network.fork_id[0].to_be_bytes().to_vec() {
+                warn!(
+                    "Wrong Fork ID. Expected {} but got {}",
+                    hex::encode(network.fork_id[0].to_be_bytes().to_vec()),
+                    hex::encode(their_status.fork_id.0)
+                );
+                return Err("Incompatible fork".into());
+            }
+
+            their_blockhash = their_status.latest_hash;
+        } else {
+            let their_status = eth::parse_status_message(uncrypted_body[1..].to_vec()).unwrap();
+
+            if their_status.fork_id.0 != network.fork_id[0].to_be_bytes().to_vec() {
+                warn!(
+                    "Wrong Fork ID. Expected {} but got {}",
+                    hex::encode(network.fork_id[0].to_be_bytes().to_vec()),
+                    hex::encode(their_status.fork_id.0)
+                );
+                return Err("Incompatible fork".into());
+            }
+
+            their_blockhash = their_status.blockhash;
+        }
+
+        /******************
+         *
+         *  Send UPGRADE STATUS message (binance only)
+         *
+         ******************/
+        if network == networks::Network::BINANCE_MAINNET {
+            let upgrade_status = eth::create_upgrade_status_message();
+            utils::send_message(
+                upgrade_status,
+                &mut stream,
+                &mut egress_mac,
+                &mut egress_aes,
+            )
+            .await?;
+        }
+
+        // Should do the loop here
+
+        let (tx_tcp, rx_tcp) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
+        let (tx_write, mut rx_write) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
+
+        let handle = tokio::spawn(async move {
+            let mut code;
+            loop {
+                tokio::select! {
+                    result = utils::read_message(&mut stream, &mut ingress_mac, &mut ingress_aes) => {
+                        let uncrypted_body = match result {
+                            Ok(b) => b,
+                            Err(e) => { warn!("Read error: {}", e); return; }
+                        };
+
+                        // handle RLPx message
+                        if uncrypted_body[0] < 16 {
+                            code = uncrypted_body[0];
+
+                            if code == 2 {
+                                // send pong
+                                let pong = message::create_pong_message();
+                                if let Err(e) = utils::send_message(pong, &mut stream, &mut egress_mac, &mut egress_aes).await {
+                                    warn!("Failed to send pong: {}", e);
+                                    return;
+                                }
+                                continue;
+                            }
+
+                            if code == 1 {
+                                let mut dec = snap::raw::Decoder::new();
+                                match dec.decompress_vec(&uncrypted_body[1..]) {
+                                    Ok(message) => warn!("Disconnected ! {}", hex::encode(&message)),
+                                    Err(_) => warn!("Disconnected ! (failed to decompress message)"),
+                                }
+                                return;
+                            }
+
+                            info!("Unknown code {}", uncrypted_body[0]);
+                            info!("{}", hex::encode(&uncrypted_body));
+                            continue;
+                        }
+
+                        if uncrypted_body[0] - 16 == 11 {
+                            let mut dec = snap::raw::Decoder::new();
+                            let message = dec.decompress_vec(&uncrypted_body[1..].to_vec()).unwrap();
+                            info!("upgrade status message received (only binance) : {}", hex::encode(&message));
+                        }
+
+                        if uncrypted_body[0] - 16 == 3 {
+                            let req_id = eth::parse_get_block_bodies(uncrypted_body[1..].to_vec());
+                            let empty_block_bodies_message = eth::create_empty_block_headers_message(&req_id);
+                            if let Err(e) = utils::send_message(empty_block_bodies_message, &mut stream, &mut egress_mac, &mut egress_aes).await {
+                                warn!("Failed to send empty headers: {}", e);
+                                return;
+                            }
+                        }
+
+                        if tx_tcp.send(uncrypted_body).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(msg) = rx_write.recv() => {
+                        if let Err(e) = utils::send_message(msg, &mut stream, &mut egress_mac, &mut egress_aes).await {
+                            warn!("Failed to send message: {}", e);
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            handle,
+            latest_blockhash: their_blockhash,
+            rx_tcp,
+            tx_write,
+            eth_protocol_version: version,
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod configs;
+pub mod connection;
 pub mod database;
 pub mod eth;
 pub mod mac;

--- a/src/main.rs
+++ b/src/main.rs
@@ -555,8 +555,12 @@ fn main() {
                     // Skip the first header: it's current_hash, already in the DB.
                     let new_headers: Vec<Block> = headers.into_iter().skip(1).collect();
                     if new_headers.is_empty() {
-                        warn!("No new block headers, waiting...");
                         pool.push_back(conn);
+                        if pool.len() == 1 {
+                            warn!("No new block headers and no other peers to try, stopping.");
+                            break 'outer;
+                        }
+                        warn!("No new block headers, waiting...");
                         tokio::time::sleep(Duration::from_secs(15)).await;
                         continue;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,15 @@
-use secp256k1::{rand, SecretKey};
 use std::collections::VecDeque;
 use std::env;
-use std::error;
-use std::net::SocketAddr;
-use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
-use std::time::SystemTime;
 use tokio::task::JoinSet;
 
 use eth_prototype::connection::Connection;
 use eth_prototype::eth;
 use eth_prototype::types::{Block, Receipt, Transaction, Withdrawal};
-use eth_prototype::{configs, database, message, networks, types, utils};
+use eth_prototype::{configs, database, networks, utils};
 
 #[macro_use]
 extern crate log;

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
     info!("Connected to database");
 
     // create the tables if they don't exist
-    database::create_tables(&network_arg, &mut postgres_client);
+    database::create_tables(&network.to_string(), &mut postgres_client);
 
     // get the hash of the next block in the chain going reverse
     // we should check if we are at the genesis block and that the parenthash is 0x0000......
@@ -200,26 +200,6 @@ fn main() {
         let mut tasks = JoinSet::new();
 
         for peer in config.peers {
-            // match run(
-            //     peer,
-            //     network,
-            //     &database_params,
-            //     &mut current_hash,
-            //     reverse,
-            //     &tx,
-            // )
-            // .await
-            // {
-            //     Ok(()) => {
-            //         // We are done
-            //         break;
-            //     }
-            //     Err(_) => {
-            //         // next peer
-            //         continue;
-            //     }
-            // };
-
             tasks.spawn(async move { Connection::connect(peer, network).await });
         }
 
@@ -464,6 +444,17 @@ fn main() {
             // arrive slowly (~12s apart).
             let mut retry_headers: Option<Vec<Block>> = None;
 
+            // Tokio-postgres client used only for re-org rollback queries.
+            let (reorg_pg_client, reorg_pg_conn) =
+                tokio_postgres::connect(&database_params, tokio_postgres::NoTls)
+                    .await
+                    .expect("to connect to database for re-org handling");
+            tokio::spawn(async move {
+                if let Err(e) = reorg_pg_conn.await {
+                    warn!("reorg postgres connection error: {}", e);
+                }
+            });
+
             'outer: loop {
                 let mut conn = match pool.pop_front() {
                     Some(c) => c,
@@ -498,25 +489,66 @@ fn main() {
                     };
 
                     let headers = eth::parse_block_headers(headers_body[1..].to_vec());
+
+                    // Empty response means the peer doesn't recognise current_hash
+                    // as canonical — assume re-org and roll back one block.
                     if headers.is_empty() {
+                        pool.push_back(conn);
+                        warn!(
+                            "Peer has no blocks after {} — assuming re-org, rolling back one block.",
+                            hex::encode(&current_hash)
+                        );
+                        let schema = network.to_string();
+                        let parent = reorg_pg_client
+                            .query_opt(
+                                &format!(
+                                    "SELECT parent_hash FROM {}.blocks WHERE hash = $1;",
+                                    schema
+                                ),
+                                &[&current_hash],
+                            )
+                            .await;
+                        match parent {
+                            Ok(Some(row)) => {
+                                let parent_hash: Vec<u8> = row.get(0);
+                                for stmt in [
+                                    format!("DELETE FROM {0}.receipts WHERE txid IN (SELECT txid FROM {0}.transactions WHERE block = $1)", schema),
+                                    format!("DELETE FROM {0}.contracts WHERE txid IN (SELECT txid FROM {0}.transactions WHERE block = $1)", schema),
+                                    format!("DELETE FROM {0}.transactions WHERE block = $1", schema),
+                                    format!("DELETE FROM {0}.withdrawals WHERE block_hash = $1", schema),
+                                    format!("DELETE FROM {0}.ommers WHERE canonical_hash = $1", schema),
+                                    format!("DELETE FROM {0}.blocks WHERE hash = $1", schema),
+                                ] {
+                                    reorg_pg_client.execute(&stmt, &[&current_hash]).await.unwrap();
+                                }
+                                warn!(
+                                    "Rolled back block {}. Resuming from parent {}.",
+                                    hex::encode(&current_hash),
+                                    hex::encode(&parent_hash)
+                                );
+                                current_hash = parent_hash;
+                            }
+                            Ok(None) => {
+                                warn!("Block {} not found in DB during re-org rollback.", hex::encode(&current_hash));
+                            }
+                            Err(e) => {
+                                warn!("Re-org rollback query failed: {}", e);
+                            }
+                        }
+                        continue;
+                    }
+
+                    // Skip the first header: it's current_hash, already in the DB.
+                    let new_headers: Vec<Block> = headers.into_iter().skip(1).collect();
+                    if new_headers.is_empty() {
                         warn!("No new block headers, waiting...");
                         pool.push_back(conn);
                         tokio::time::sleep(Duration::from_secs(15)).await;
                         continue;
                     }
 
-                    // Skip the first header: it's current_hash, which is
-                    // already in the DB. The peer returns it inclusive.
-                    let headers: Vec<Block> = headers.into_iter().skip(1).collect();
-                    if headers.is_empty() {
-                        warn!("No new block headers, waiting...");
-                        pool.push_back(conn);
-                        tokio::time::sleep(Duration::from_secs(15)).await;
-                        continue;
-                    }
-
-                    current_hash = headers.last().unwrap().hash.to_vec();
-                    headers
+                    current_hash = new_headers.last().unwrap().hash.to_vec();
+                    new_headers
                 };
 
                 let hashes: Vec<Vec<u8>> =

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,12 @@ use eth_prototype::networks::Network;
 use rand::Rng;
 use secp256k1::rand::RngCore;
 use secp256k1::{rand, SecretKey};
+use std::collections::VecDeque;
 use std::env;
 use std::error;
 use std::net::SocketAddr;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
@@ -143,22 +145,53 @@ fn main() {
         let mut postgres_client = postgres::Client::connect(&db_params, postgres::NoTls).unwrap();
 
         // while recv save blocks in database
-        loop {
-            let blocks: Vec<(
-                Block,
-                Vec<Transaction>,
-                Vec<Block>,
-                Vec<Withdrawal>,
-                Vec<Receipt>,
-            )> = rx.blocking_recv().unwrap();
-            database::save_blocks(&blocks, &network_arg, &mut postgres_client);
+        // Out-of-order batches are held in a cache keyed by their first block
+        // number until the missing predecessor arrives.
+        type Batch = Vec<(
+            Block,
+            Vec<Transaction>,
+            Vec<Block>,
+            Vec<Withdrawal>,
+            Vec<Receipt>,
+        )>;
+        let mut last_block_number: Option<u32> = None;
+        let mut cache: std::collections::BTreeMap<u32, Batch> = std::collections::BTreeMap::new();
 
-            // We are synced
-            if network.genesis_hash.to_vec() == blocks.last().unwrap().0.hash.to_vec() {
-                info!("We are synced ! We are creating the indexes on the tables... This will take a while.");
-                // Open, read and execute SQL scripts at the end of sync
-                utils::open_exec_sql_file(&network_arg, &mut postgres_client);
-                break;
+        'recv: loop {
+            let blocks: Batch = rx.blocking_recv().unwrap();
+
+            let first_number = blocks.first().unwrap().0.number;
+            let is_contiguous = last_block_number
+                .map(|last| last.abs_diff(first_number) == 1)
+                .unwrap_or(true);
+
+            if !is_contiguous {
+                info!(
+                    "Caching out-of-order batch starting at block {} (last saved: {:?})",
+                    first_number, last_block_number
+                );
+                cache.insert(first_number, blocks);
+                continue;
+            }
+
+            // Save this batch then drain any cached batches that are now contiguous.
+            let mut to_save: Option<Batch> = Some(blocks);
+            while let Some(batch) = to_save {
+                database::save_blocks(&batch, &network_arg, &mut postgres_client);
+                let last = batch.last().unwrap().0.number;
+                last_block_number = Some(last);
+
+                if network.genesis_hash.to_vec() == batch.last().unwrap().0.hash.to_vec() {
+                    info!("We are synced ! We are creating the indexes on the tables... This will take a while.");
+                    utils::open_exec_sql_file(&network_arg, &mut postgres_client);
+                    break 'recv;
+                }
+
+                // Look for a cached batch whose first block is adjacent to `last`.
+                to_save = last
+                    .checked_sub(1)
+                    .and_then(|k| cache.remove(&k))
+                    .or_else(|| cache.remove(&(last + 1)));
             }
         }
 
@@ -250,135 +283,189 @@ fn main() {
             }
         }
 
-        // Fetch blocks from a random connection
-        loop {
-            if connections.is_empty() {
-                warn!("No connections left");
+        // Fetch blocks - pipeline header requests across connections while
+        // bodies/receipts are fetched concurrently in spawned tasks.
+        // Tasks return Ok(conn) on success or Err(block_headers) so the batch
+        // can be retried on a different connection.
+        let done = Arc::new(AtomicBool::new(false));
+        let mut pool: VecDeque<Connection> = connections.into_iter().collect();
+        let mut body_tasks: JoinSet<Result<Connection, Vec<Block>>> = JoinSet::new();
+        let mut retry_queue: VecDeque<Vec<Block>> = VecDeque::new();
+
+        'outer: loop {
+            if done.load(Ordering::Relaxed) {
                 break;
             }
 
-            let idx = rand::thread_rng().gen_range(0..connections.len());
-            let conn = &mut connections[idx];
-
-            // Send GetBlockHeaders
-            info!(
-                "Sending GetBlockHeaders (starting {})",
-                hex::encode(&current_hash)
-            );
-            let get_headers =
-                eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, reverse);
-            if conn.tx_write.send(get_headers).await.is_err() {
-                warn!("Connection {} lost, removing", idx);
-                connections.remove(idx);
-                continue;
-            }
-
-            // Wait for BlockHeaders (code 4)
-            let headers_body = loop {
-                match conn.rx_tcp.recv().await {
-                    Some(body) if body[0].saturating_sub(16) == 4 => break Some(body),
-                    Some(_) => continue,
-                    None => break None,
+            // Get an available connection; if the pool is empty wait for a
+            // body task to finish and reclaim its connection (or a retry batch).
+            let mut conn = loop {
+                if let Some(c) = pool.pop_front() {
+                    break c;
                 }
-            };
-            let headers_body = match headers_body {
-                Some(b) => b,
-                None => {
-                    connections.remove(idx);
-                    continue;
-                }
-            };
-
-            let block_headers = eth::parse_block_headers(headers_body[1..].to_vec());
-            if block_headers.is_empty() {
-                warn!("No block headers received");
-                break;
-            }
-
-            // Update current_hash for next batch
-            if reverse {
-                current_hash = block_headers.last().unwrap().parent_hash.to_vec();
-            } else {
-                current_hash = block_headers.last().unwrap().hash.to_vec();
-            }
-
-            let hashes: Vec<Vec<u8>> = block_headers.iter().map(|b| b.hash.clone()).collect();
-
-            // Send GetBlockBodies, looping until all bodies are received
-            let mut transactions: Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> = vec![];
-            while transactions.len() < hashes.len() {
-                info!(
-                    "Sending GetBlockBodies ({}/{})",
-                    transactions.len(),
-                    hashes.len()
-                );
-                let get_bodies =
-                    eth::create_get_block_bodies_message(&hashes[transactions.len()..].to_vec());
-                conn.tx_write.send(get_bodies).await.unwrap();
-
-                // Wait for BlockBodies (code 6)
-                loop {
-                    match conn.rx_tcp.recv().await {
-                        Some(body) if body[0].saturating_sub(16) == 6 => {
-                            transactions.extend(eth::parse_block_bodies(body[1..].to_vec()));
-                            break;
-                        }
-                        Some(_) => continue,
-                        None => break,
+                match body_tasks.join_next().await {
+                    Some(Ok(Ok(c))) => pool.push_back(c),
+                    Some(Ok(Err(headers))) => {
+                        warn!("Task failed, re-queuing batch of {} headers", headers.len());
+                        retry_queue.push_back(headers);
+                    }
+                    Some(Err(e)) => warn!("Body task panicked: {:?}", e),
+                    None => {
+                        warn!("No connections left");
+                        break 'outer;
                     }
                 }
-            }
+            };
 
-            // Fetch receipts (eth69 only)
-            let mut receipts: Vec<Vec<Receipt>> = vec![];
-            if conn.eth_protocol_version == 69 {
-                while receipts.len() < hashes.len() {
-                    info!("Sending GetReceipts ({}/{})", receipts.len(), hashes.len());
-                    let get_receipts =
-                        eth::create_get_receipts_message(&hashes[receipts.len()..].to_vec());
-                    conn.tx_write.send(get_receipts).await.unwrap();
+            // Use a pending retry batch or fetch new headers from the peer.
+            let block_headers = if let Some(headers) = retry_queue.pop_front() {
+                info!(
+                    "Retrying batch of {} headers on new connection",
+                    headers.len()
+                );
+                headers
+            } else {
+                // Send GetBlockHeaders
+                info!(
+                    "Sending GetBlockHeaders (starting {})",
+                    hex::encode(&current_hash)
+                );
+                let get_headers =
+                    eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, reverse);
+                if conn.tx_write.send(get_headers).await.is_err() {
+                    warn!("Connection lost, dropping");
+                    continue;
+                }
 
-                    // Wait for Receipts (code 16)
+                // Wait for BlockHeaders (code 4)
+                let headers_body = loop {
+                    match conn.rx_tcp.recv().await {
+                        Some(body) if body[0].saturating_sub(16) == 4 => break Some(body),
+                        Some(_) => continue,
+                        None => break None,
+                    }
+                };
+                let headers_body = match headers_body {
+                    Some(b) => b,
+                    None => continue,
+                };
+
+                let headers = eth::parse_block_headers(headers_body[1..].to_vec());
+                if headers.is_empty() {
+                    warn!("No block headers received");
+                    pool.push_back(conn);
+                    break;
+                }
+
+                // Update current_hash before spawning so the next iteration
+                // immediately starts fetching the following batch.
+                if reverse {
+                    current_hash = headers.last().unwrap().parent_hash.to_vec();
+                } else {
+                    current_hash = headers.last().unwrap().hash.to_vec();
+                }
+
+                headers
+            };
+
+            let tx_clone = tx.clone();
+            let done_clone = done.clone();
+            body_tasks.spawn(async move {
+                let mut conn = conn;
+                let hashes: Vec<Vec<u8>> = block_headers.iter().map(|b| b.hash.clone()).collect();
+                let eth_version = conn.eth_protocol_version;
+
+                // Fetch block bodies
+                let mut transactions: Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> = vec![];
+                while transactions.len() < hashes.len() {
+                    info!(
+                        "Sending GetBlockBodies ({}/{})",
+                        transactions.len(),
+                        hashes.len()
+                    );
+                    let get_bodies = eth::create_get_block_bodies_message(
+                        &hashes[transactions.len()..].to_vec(),
+                    );
+                    if conn.tx_write.send(get_bodies).await.is_err() {
+                        warn!("Connection lost during GetBlockBodies, will retry batch");
+                        return Err(block_headers);
+                    }
                     loop {
                         match conn.rx_tcp.recv().await {
-                            Some(body) if body[0].saturating_sub(16) == 16 => {
-                                receipts.extend(eth::parse_receipts(body[1..].to_vec()));
+                            Some(body) if body[0].saturating_sub(16) == 6 => {
+                                transactions.extend(eth::parse_block_bodies(body[1..].to_vec()));
                                 break;
                             }
                             Some(_) => continue,
-                            None => break,
+                            None => {
+                                warn!("Connection closed during GetBlockBodies, will retry batch");
+                                return Err(block_headers);
+                            }
                         }
                     }
                 }
-            }
 
-            let blocks: Vec<_> = block_headers
-                .iter()
-                .enumerate()
-                .map(|(i, header)| {
-                    let (txs, ommers, withdrawals) = transactions[i].clone();
-                    let block_receipts = if conn.eth_protocol_version == 69 {
-                        receipts[i].clone()
-                    } else {
-                        vec![]
-                    };
-                    (header.clone(), txs, ommers, withdrawals, block_receipts)
-                })
-                .collect();
+                // Fetch receipts (eth69 only)
+                let mut receipts: Vec<Vec<Receipt>> = vec![];
+                if eth_version == 69 {
+                    while receipts.len() < hashes.len() {
+                        info!("Sending GetReceipts ({}/{})", receipts.len(), hashes.len());
+                        let get_receipts =
+                            eth::create_get_receipts_message(&hashes[receipts.len()..].to_vec());
+                        if conn.tx_write.send(get_receipts).await.is_err() {
+                            warn!("Connection lost during GetReceipts, will retry batch");
+                            return Err(block_headers);
+                        }
+                        loop {
+                            match conn.rx_tcp.recv().await {
+                                Some(body) if body[0].saturating_sub(16) == 16 => {
+                                    receipts.extend(eth::parse_receipts(body[1..].to_vec()));
+                                    break;
+                                }
+                                Some(_) => continue,
+                                None => {
+                                    warn!("Connection closed during GetReceipts, will retry batch");
+                                    return Err(block_headers);
+                                }
+                            }
+                        }
+                    }
+                }
 
-            let current_height = blocks.last().unwrap().0.number;
-            info!("Blocks n° {}", current_height);
+                let blocks: Vec<_> = block_headers
+                    .iter()
+                    .enumerate()
+                    .map(|(i, header)| {
+                        let (txs, ommers, withdrawals) = transactions[i].clone();
+                        let block_receipts = if eth_version == 69 {
+                            receipts[i].clone()
+                        } else {
+                            vec![]
+                        };
+                        (header.clone(), txs, ommers, withdrawals, block_receipts)
+                    })
+                    .collect();
 
-            if tx.send(blocks).await.is_err() {
-                warn!("DB channel closed");
-                break;
-            }
+                let current_height = blocks.last().unwrap().0.number;
+                info!("Blocks n° {}", current_height);
 
-            if current_height == 0 {
-                info!("Data fully synced");
-                break;
-            }
+                if tx_clone.send(blocks).await.is_err() {
+                    warn!("DB channel closed");
+                    return Err(block_headers);
+                }
+
+                if current_height == 0 {
+                    info!("Data fully synced");
+                    done_clone.store(true, Ordering::Relaxed);
+                    return Ok(conn);
+                }
+
+                Ok(conn)
+            });
         }
+
+        // Drain remaining body tasks before exiting
+        while body_tasks.join_next().await.is_some() {}
     });
 
     // need to wait for database thread to finish

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use eth_prototype::configs::Peer;
 use eth_prototype::networks::Network;
+use rand::Rng;
 use secp256k1::rand::RngCore;
 use secp256k1::{rand, SecretKey};
 use std::env;
@@ -11,8 +12,9 @@ use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 use std::time::SystemTime;
-use tokio::net::TcpStream;
+use tokio::task::JoinSet;
 
+use eth_prototype::connection::Connection;
 use eth_prototype::eth;
 use eth_prototype::types::{Block, Receipt, Transaction, Withdrawal};
 use eth_prototype::{configs, database, message, networks, types, utils};
@@ -165,29 +167,218 @@ fn main() {
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
+        let mut connections: Vec<Connection> = vec![];
+        let mut tasks = JoinSet::new();
+
         for peer in config.peers {
-            match run(
-                peer,
-                network,
-                &database_params,
-                &mut current_hash,
-                reverse,
-                &tx,
-            )
-            .await
-            {
-                Ok(()) => {
-                    // We are done
-                    break;
+            // match run(
+            //     peer,
+            //     network,
+            //     &database_params,
+            //     &mut current_hash,
+            //     reverse,
+            //     &tx,
+            // )
+            // .await
+            // {
+            //     Ok(()) => {
+            //         // We are done
+            //         break;
+            //     }
+            //     Err(_) => {
+            //         // next peer
+            //         continue;
+            //     }
+            // };
+
+            tasks.spawn(async move { Connection::connect(peer, network).await });
+        }
+
+        while let Some(result) = tasks.join_next().await {
+            match result {
+                Ok(Ok(connection)) => {
+                    info!("Connection established");
+                    connections.push(connection);
                 }
-                Err(_) => {
-                    // next peer
-                    continue;
-                }
-            };
+                Ok(Err(e)) => warn!("Failed to connect to peer: {}", e),
+                Err(e) => warn!("Task panicked: {:?}", e),
+            }
         }
 
         info!("Tried all peers");
+
+        // Find the best hash among all the connections
+        let mut counts: std::collections::HashMap<Vec<u8>, usize> =
+            std::collections::HashMap::new();
+        for conn in connections.iter() {
+            *counts.entry(conn.latest_blockhash().clone()).or_insert(0) += 1;
+        }
+        if let Some((best_hash, count)) = counts.into_iter().max_by_key(|(_, c)| *c) {
+            info!(
+                "Most common blockhash ({} peers): {}",
+                count,
+                hex::encode(&best_hash)
+            );
+
+            // If we are already synced and we are saving new blocks, lets verify that we don't have the already highest block from this peer.
+            // Sometimes peers are stuck and don't have new blocks. We need to disconnect from those.
+            if !reverse {
+                // We need to go one block back
+                let mut postgres_client =
+                    postgres::Client::connect(&database_params, postgres::NoTls)
+                        .expect("to connect to database");
+                let result = postgres_client
+                    .query(
+                        format!(
+                            "SELECT * FROM {0}.blocks WHERE hash = '\\x{1}';",
+                            network.to_string(),
+                            hex::encode(&best_hash)
+                        )
+                        .as_str(),
+                        &[],
+                    )
+                    .unwrap();
+
+                if result.len() > 0 {
+                    warn!("We already have their latets block");
+                }
+            }
+
+            // If we don't have blocks in the database we use the best one
+            if current_hash.len() == 0 {
+                current_hash = best_hash;
+            }
+        }
+
+        // Fetch blocks from a random connection
+        loop {
+            if connections.is_empty() {
+                warn!("No connections left");
+                break;
+            }
+
+            let idx = rand::thread_rng().gen_range(0..connections.len());
+            let conn = &mut connections[idx];
+
+            // Send GetBlockHeaders
+            info!(
+                "Sending GetBlockHeaders (starting {})",
+                hex::encode(&current_hash)
+            );
+            let get_headers =
+                eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, reverse);
+            if conn.tx_write.send(get_headers).await.is_err() {
+                warn!("Connection {} lost, removing", idx);
+                connections.remove(idx);
+                continue;
+            }
+
+            // Wait for BlockHeaders (code 4)
+            let headers_body = loop {
+                match conn.rx_tcp.recv().await {
+                    Some(body) if body[0].saturating_sub(16) == 4 => break Some(body),
+                    Some(_) => continue,
+                    None => break None,
+                }
+            };
+            let headers_body = match headers_body {
+                Some(b) => b,
+                None => {
+                    connections.remove(idx);
+                    continue;
+                }
+            };
+
+            let block_headers = eth::parse_block_headers(headers_body[1..].to_vec());
+            if block_headers.is_empty() {
+                warn!("No block headers received");
+                break;
+            }
+
+            // Update current_hash for next batch
+            if reverse {
+                current_hash = block_headers.last().unwrap().parent_hash.to_vec();
+            } else {
+                current_hash = block_headers.last().unwrap().hash.to_vec();
+            }
+
+            let hashes: Vec<Vec<u8>> = block_headers.iter().map(|b| b.hash.clone()).collect();
+
+            // Send GetBlockBodies, looping until all bodies are received
+            let mut transactions: Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> = vec![];
+            while transactions.len() < hashes.len() {
+                info!(
+                    "Sending GetBlockBodies ({}/{})",
+                    transactions.len(),
+                    hashes.len()
+                );
+                let get_bodies =
+                    eth::create_get_block_bodies_message(&hashes[transactions.len()..].to_vec());
+                conn.tx_write.send(get_bodies).await.unwrap();
+
+                // Wait for BlockBodies (code 6)
+                loop {
+                    match conn.rx_tcp.recv().await {
+                        Some(body) if body[0].saturating_sub(16) == 6 => {
+                            transactions.extend(eth::parse_block_bodies(body[1..].to_vec()));
+                            break;
+                        }
+                        Some(_) => continue,
+                        None => break,
+                    }
+                }
+            }
+
+            // Fetch receipts (eth69 only)
+            let mut receipts: Vec<Vec<Receipt>> = vec![];
+            if conn.eth_protocol_version == 69 {
+                while receipts.len() < hashes.len() {
+                    info!("Sending GetReceipts ({}/{})", receipts.len(), hashes.len());
+                    let get_receipts =
+                        eth::create_get_receipts_message(&hashes[receipts.len()..].to_vec());
+                    conn.tx_write.send(get_receipts).await.unwrap();
+
+                    // Wait for Receipts (code 16)
+                    loop {
+                        match conn.rx_tcp.recv().await {
+                            Some(body) if body[0].saturating_sub(16) == 16 => {
+                                receipts.extend(eth::parse_receipts(body[1..].to_vec()));
+                                break;
+                            }
+                            Some(_) => continue,
+                            None => break,
+                        }
+                    }
+                }
+            }
+
+            let blocks: Vec<_> = block_headers
+                .iter()
+                .enumerate()
+                .map(|(i, header)| {
+                    let (txs, ommers, withdrawals) = transactions[i].clone();
+                    let block_receipts = if conn.eth_protocol_version == 69 {
+                        receipts[i].clone()
+                    } else {
+                        vec![]
+                    };
+                    (header.clone(), txs, ommers, withdrawals, block_receipts)
+                })
+                .collect();
+
+            let current_height = blocks.last().unwrap().0.number;
+            info!("Blocks n° {}", current_height);
+
+            if tx.send(blocks).await.is_err() {
+                warn!("DB channel closed");
+                break;
+            }
+
+            if current_height == 0 {
+                info!("Data fully synced");
+                break;
+            }
+        }
     });
 
     // need to wait for database thread to finish
@@ -209,234 +400,10 @@ async fn run(
             Vec<Receipt>,
         )>,
     >,
-) -> Result<(), Box<dyn error::Error>> {
-    /******************
-     *
-     *  Connect to peer
-     *
-     ******************/
-    let mut stream = tokio::time::timeout(
-        Duration::from_secs(3),
-        TcpStream::connect(SocketAddr::from_str(&format!("{}:{}", peer.ip, peer.port)).unwrap()),
-    )
-    .await??;
-
-    let private_key = SecretKey::new(&mut rand::thread_rng())
-        .secret_bytes()
-        .to_vec();
-    let mut nonce = vec![0; 32];
-    rand::thread_rng().fill_bytes(&mut nonce);
-    let ephemeral_privkey = SecretKey::new(&mut rand::thread_rng())
-        .secret_bytes()
-        .to_vec();
-    let pad = vec![0; 100]; // should be generated randomly but we don't really care
-
-    /******************
-     *
-     *  Create Auth message (EIP8 supported)
-     *
-     ******************/
-    info!("Creating EIP8 Auth message");
-    let init_msg = utils::create_auth_eip8(
-        &peer.remote_id,
-        &private_key,
-        &nonce,
-        &ephemeral_privkey,
-        &pad,
-    );
-
-    // send the message
-    info!("Sending EIP8 Auth message");
-    utils::send_eip8_auth_message(&init_msg, &mut stream).await?;
-
-    info!("waiting for answer... (ACK message)");
-    let (payload, shared_mac_data) = utils::read_ack_message(&mut stream).await?;
-
-    /******************
-     *
-     *  Handle Ack
-     *
-     ******************/
-
-    info!("ACK message received");
-    info!("Received Ack");
-    if payload[0] != 0x04 {
-        return Err("Didn't received ACK when expecting it".into());
-    }
-
-    let (_remote_public_key, remote_nonce, ephemeral_shared_secret) =
-        utils::handle_ack_message(&payload, &shared_mac_data, &private_key, &ephemeral_privkey);
-
-    /******************
-     *
-     *  Setup Frame
-     *
-     ******************/
-
-    let remote_data = [shared_mac_data, payload].concat();
-    let (mut ingress_aes, mut ingress_mac, egress_aes, egress_mac) = utils::setup_frame(
-        remote_nonce,
-        nonce,
-        ephemeral_shared_secret,
-        remote_data,
-        init_msg,
-    );
-    let egress_aes = Arc::new(Mutex::new(egress_aes));
-    let egress_mac = Arc::new(Mutex::new(egress_mac));
-    let stream = Arc::new(tokio::sync::Mutex::new(stream));
-
-    info!("Frame setup done !");
-
-    info!("Received Ack, waiting for Header");
-
-    /******************
-     *
-     *  Handle HELLO
-     *
-     ******************/
-
-    let uncrypted_body = utils::read_message(&stream, &mut ingress_mac, &mut ingress_aes).await?;
-
-    if uncrypted_body[0] == 0x01 {
-        warn!("Disconnect message : {}", hex::encode(&uncrypted_body));
-
-        return Err("Disconnected peer".into());
-    }
-
-    // Should be HELLO
-    assert_eq!(0x80, uncrypted_body[0]);
-    let hello_message = message::parse_hello_message(uncrypted_body[1..].to_vec());
-
-    info!(
-        "HelloMessage {}",
-        serde_json::to_string(&hello_message).unwrap()
-    );
-
-    // We need to find the highest eth version it supports
-    let _capabilities = serde_json::to_string(&hello_message.capabilities).unwrap();
-
-    // We need to find the highest eth version it supports
-    let mut version = 0;
-    for capability in &hello_message.capabilities {
-        if capability.0.to_string() == "eth" {
-            if capability.1 > version {
-                version = capability.1;
-            }
-        }
-    }
-
-    /******************
-     *
-     *  Create Hello
-     *
-     ******************/
-
-    info!("Sending HELLO message");
-    let secp = secp256k1::Secp256k1::new();
-    let private_key = secp256k1::SecretKey::from_slice(&private_key).unwrap();
-    let hello_message = types::HelloMessage {
-        protocol_version: message::BASE_PROTOCOL_VERSION,
-        client: String::from("deadbrain corp."),
-        capabilities: vec![("eth".into(), 67), ("eth".into(), 68), ("eth".into(), 69)],
-        port: 0,
-        id: secp256k1::PublicKey::from_secret_key(&secp, &private_key).serialize_uncompressed()
-            [1..]
-            .to_vec(),
-    };
-    let hello = message::create_hello_message(hello_message);
-    utils::send_message(hello, &stream, &egress_mac, &egress_aes).await?;
-
-    /******************
-     *
-     *  Send STATUS message
-     *
-     ******************/
-
-    info!("Sending STATUS message");
-
-    let payload: Vec<u8>;
-    if version == 69 {
-        let status = eth::Status69 {
-            version,
-            network_id: network.network_id,
-            genesis: network.genesis_hash.to_vec(),
-            fork_id: (network.fork_id[0].to_be_bytes().to_vec(), 0),
-            earliest: 0,
-            latest: 0,
-            latest_hash: network.genesis_hash.to_vec(),
-        };
-        payload = eth::create_eth69_status_message(status);
-    } else {
-        let status = eth::Status {
-            version,
-            network_id: network.network_id,
-            td: network
-                .head_td
-                .to_be_bytes()
-                .iter()
-                .skip_while(|x| **x == 0)
-                .map(|x| *x)
-                .collect(), // Maybe I should just have change the status type. But this is needed for now to remove the zeroes at the begining
-            blockhash: network.genesis_hash.to_vec(),
-            genesis: network.genesis_hash.to_vec(),
-            fork_id: (network.fork_id[0].to_be_bytes().to_vec(), 0),
-        };
-        payload = eth::create_status_message(status);
-    }
-    utils::send_message(payload, &stream, &egress_mac, &egress_aes).await?;
-
-    /******************
-     *
-     *  Handle STATUS message
-     *
-     ******************/
-
-    info!("Handling STATUS message");
-    let uncrypted_body = utils::read_message(&stream, &mut ingress_mac, &mut ingress_aes).await?;
-    if uncrypted_body[0] == 0x01 {
-        warn!("Disconnect message : {}", hex::encode(&uncrypted_body));
-
-        return Err("Disconnected peer".into());
-    }
-
-    let their_blockhash: Vec<u8>;
-    if version == 69 {
-        let their_status = eth::parse_eth69_status_message(uncrypted_body[1..].to_vec()).unwrap();
-
-        if their_status.fork_id.0 != network.fork_id[0].to_be_bytes().to_vec() {
-            warn!(
-                "Wrong Fork ID. Expected {} but got {}",
-                hex::encode(network.fork_id[0].to_be_bytes().to_vec()),
-                hex::encode(their_status.fork_id.0)
-            );
-            return Err("Incompatible fork".into());
-        }
-
-        their_blockhash = their_status.latest_hash;
-    } else {
-        let their_status = eth::parse_status_message(uncrypted_body[1..].to_vec()).unwrap();
-
-        if their_status.fork_id.0 != network.fork_id[0].to_be_bytes().to_vec() {
-            warn!(
-                "Wrong Fork ID. Expected {} but got {}",
-                hex::encode(network.fork_id[0].to_be_bytes().to_vec()),
-                hex::encode(their_status.fork_id.0)
-            );
-            return Err("Incompatible fork".into());
-        }
-
-        their_blockhash = their_status.blockhash;
-    }
-
-    /******************
-     *
-     *  Send UPGRADE STATUS message (binance only)
-     *
-     ******************/
-    if network == networks::Network::BINANCE_MAINNET {
-        let upgrade_status = eth::create_upgrade_status_message();
-        utils::send_message(upgrade_status, &stream, &egress_mac, &egress_aes).await?;
-    }
+) -> Result<(), Box<dyn error::Error + Send + Sync>> {
+    // Connect to the peer
+    let connection = Connection::connect(peer, network).await?;
+    let their_blockhash = connection.latest_blockhash();
 
     // If we are already synced and we are saving new blocks, lets verify that we don't have the already highest block from this peer.
     // Sometimes peers are stuck and don't have new blocks. We need to disconnect from those.
@@ -449,7 +416,7 @@ async fn run(
                 format!(
                     "SELECT * FROM {0}.blocks WHERE hash = '\\x{1}';",
                     network.to_string(),
-                    hex::encode(&their_blockhash)
+                    hex::encode(their_blockhash)
                 )
                 .as_str(),
                 &[],
@@ -464,7 +431,7 @@ async fn run(
 
     // If we don't have blocks in the database we use the best one
     if current_hash.len() == 0 {
-        *current_hash = their_blockhash;
+        *current_hash = connection.latest_blockhash().clone();
     }
 
     /****************************
@@ -473,319 +440,234 @@ async fn run(
      *
      ****************************/
 
-    let thread_stream = Arc::clone(&stream);
-    let thread_egress_mac = Arc::clone(&egress_mac);
-    let thread_egress_aes = Arc::clone(&egress_aes);
+    // loop {
+    //     /******************
+    //      *
+    //      *  Send GetBlockHeaders message
+    //      *
+    //      ******************/
+    //     info!(
+    //         "Sending GetBlockHeaders message (starting {})",
+    //         hex::encode(&current_hash)
+    //     );
 
-    let (tx_tcp, mut rx_tcp) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
+    //     let get_blocks_headers =
+    //         eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, reverse);
+    //     utils::send_message(get_blocks_headers, &stream, &egress_mac, &egress_aes).await?;
 
-    let tcp_handle = tokio::spawn(async move {
-        let mut uncrypted_body: Vec<u8>;
-        let mut code;
-        loop {
-            uncrypted_body =
-                utils::read_message(&thread_stream, &mut ingress_mac, &mut ingress_aes)
-                    .await
-                    .unwrap();
+    //     /******************
+    //      *
+    //      *  Handle BlockHeader message
+    //      *
+    //      ******************/
+    //     info!("Handling BlockHeaders message");
+    //     let mut uncrypted_body: Vec<u8>;
+    //     let mut code;
+    //     loop {
+    //         uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
 
-            // handle RLPx message
-            if uncrypted_body[0] < 16 {
-                code = uncrypted_body[0];
+    //         code = uncrypted_body[0] - 16;
+    //         if code == 4 {
+    //             break;
+    //         }
+    //     }
 
-                if code == 2 {
-                    // send pong
-                    let pong = message::create_pong_message();
+    //     assert_eq!(code, 4);
 
-                    utils::send_message(
-                        pong,
-                        &thread_stream,
-                        &thread_egress_mac,
-                        &thread_egress_aes,
-                    )
-                    .await
-                    .unwrap();
+    //     let block_headers = eth::parse_block_headers(uncrypted_body[1..].to_vec());
 
-                    continue;
-                }
+    //     // update block hash
+    //     if reverse {
+    //         *current_hash = block_headers.last().unwrap().parent_hash.to_vec();
+    //     } else {
+    //         if block_headers.len() == 0 {
+    //             warn!("No block founds");
 
-                if code == 1 {
-                    // Received a disconnect message
-                    let mut dec = snap::raw::Decoder::new();
-                    let message = dec.decompress_vec(&uncrypted_body[1..].to_vec()).unwrap();
+    //             // We need to go one block back
+    //             let mut postgres_client =
+    //                 postgres::Client::connect(&database_params, postgres::NoTls)
+    //                     .expect("to connect to database");
+    //             let result = postgres_client.query(format!("SELECT parent_hash, hash, number FROM {0}.blocks WHERE number = (SELECT MAX(number) FROM {0}.blocks);", network.to_string()).as_str(), &[]).unwrap();
 
-                    warn!("Disconnected ! {}", hex::encode(&message));
+    //             let hash: Vec<u8> = result[0].try_get(1).unwrap();
+    //             match result[0].try_get(0) {
+    //                 Ok(h) => {
+    //                     *current_hash = h;
+    //                 }
+    //                 Err(_) => {
+    //                     error!("Fail to get hash of the minimum block");
+    //                 }
+    //             }
 
-                    return;
-                }
+    //             // Delete the block we cannot find anymore
+    //             info!(
+    //                 "Deleting block {} on network {}",
+    //                 hex::encode(&hash),
+    //                 network.to_string()
+    //             );
+    //             postgres_client.batch_execute(format!("DELETE FROM {0}.transactions WHERE block = '\\x{1}'; DELETE FROM {0}.blocks WHERE hash = '\\x{1}';", network.to_string(), hex::encode(&hash)).as_str()).unwrap();
 
-                info!("Unknown code {}", uncrypted_body[0]);
-                info!("{}", hex::encode(&uncrypted_body));
+    //             continue;
+    //         }
 
-                continue;
-            }
+    //         let last_block = block_headers.last().unwrap();
 
-            if uncrypted_body[0] - 16 == 11 {
-                let mut dec = snap::raw::Decoder::new();
-                let message = dec.decompress_vec(&uncrypted_body[1..].to_vec()).unwrap();
-                info!(
-                    "upgrade status message received (only binance) : {}",
-                    hex::encode(&message)
-                );
-            }
+    //         // Verify if the block has ben created less than 600 seconds ago (1hr). Blocks are being created every 15 seconds.
+    //         if SystemTime::now()
+    //             .duration_since(SystemTime::UNIX_EPOCH)
+    //             .unwrap()
+    //             .as_secs() as u32
+    //             - last_block.time
+    //             < 600
+    //         {
+    //             trace!("We have the latest created block. Waiting 15 seconds.");
+    //             tokio::time::sleep(Duration::from_secs(15)).await;
+    //         } else {
+    //             // if the last block is older than 1hr we are assuming the node is not receiving new blocks
+    //             if current_hash.as_slice() == last_block.hash.as_slice() {
+    //                 warn!("Last block is our current block");
+    //                 return Err("No new blocks".into());
+    //             }
+    //         }
 
-            if uncrypted_body[0] - 16 == 3 {
-                // Rospten node keep asking us for new block headers that we don't have
-                // Working with Geth/v1.10.23-stable-d901d853 but not v1.10.21
-                let req_id = eth::parse_get_block_bodies(uncrypted_body[1..].to_vec());
-                let empty_block_bodies_message = eth::create_empty_block_headers_message(&req_id);
+    //         *current_hash = last_block.hash.to_vec();
+    //     }
 
-                utils::send_message(
-                    empty_block_bodies_message,
-                    &thread_stream,
-                    &thread_egress_mac,
-                    &thread_egress_aes,
-                )
-                .await
-                .unwrap();
-            }
+    //     /******************
+    //      *
+    //      *  Send GetBlockBodies message
+    //      *
+    //      ******************/
+    //     info!("Sending GetBlockBodies message");
+    //     let hashes = block_headers
+    //         .iter()
+    //         .map(|b| b.hash.clone())
+    //         .collect::<Vec<Vec<u8>>>();
 
-            if tx_tcp.send(uncrypted_body).await.is_err() {
-                break;
-            }
-        }
-    });
+    //     let mut transactions: Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> = vec![];
 
-    loop {
-        /******************
-         *
-         *  Send GetBlockHeaders message
-         *
-         ******************/
+    //     while transactions.len() < hashes.len() {
+    //         let get_blocks_bodies =
+    //             eth::create_get_block_bodies_message(&hashes[transactions.len()..].to_vec());
+    //         utils::send_message(get_blocks_bodies, &stream, &egress_mac, &egress_aes).await?;
 
-        info!(
-            "Sending GetBlockHeaders message (starting {})",
-            hex::encode(&current_hash)
-        );
+    //         /******************
+    //          *
+    //          *  Handle BlockHeader message
+    //          *
+    //          ******************/
+    //         let mut uncrypted_body: Vec<u8>;
+    //         let mut code;
+    //         loop {
+    //             uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
 
-        let get_blocks_headers =
-            eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, reverse);
-        utils::send_message(get_blocks_headers, &stream, &egress_mac, &egress_aes).await?;
+    //             code = uncrypted_body[0] - 16;
+    //             if code == 6 {
+    //                 break;
+    //             }
+    //         }
+    //         assert_eq!(code, 6);
 
-        /******************
-         *
-         *  Handle BlockHeader message
-         *
-         ******************/
+    //         let tmp_txs = eth::parse_block_bodies(uncrypted_body[1..].to_vec());
+    //         transactions.extend(tmp_txs);
 
-        info!("Handling BlockHeaders message");
-        let mut uncrypted_body: Vec<u8>;
-        let mut code;
-        loop {
-            uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
+    //         info!(
+    //             "Handling BlockBodies message ({}/{} block bodies received)",
+    //             transactions.len(),
+    //             hashes.len()
+    //         );
+    //     }
 
-            code = uncrypted_body[0] - 16;
-            if code == 4 {
-                break;
-            }
-        }
+    //     /******************
+    //      *
+    //      *  Send GetReceipts message
+    //      *
+    //      ******************/
+    //     // TODO: implement ETH 69 to be able to get receipts. Older protocols support it but are more of a struggle to implement.
+    //     info!("Sending GetReceipts message");
+    //     let mut receipts: Vec<Vec<Receipt>> = vec![];
 
-        assert_eq!(code, 4);
+    //     if version == 69 {
+    //         while receipts.len() < hashes.len() {
+    //             let get_receipts =
+    //                 eth::create_get_receipts_message(&hashes[receipts.len()..].to_vec());
+    //             utils::send_message(get_receipts, &stream, &egress_mac, &egress_aes).await?;
 
-        let block_headers = eth::parse_block_headers(uncrypted_body[1..].to_vec());
+    //             /******************
+    //              *
+    //              *  Handle Receipts message
+    //              *
+    //              ******************/
+    //             let mut uncrypted_body: Vec<u8>;
+    //             let mut code;
+    //             loop {
+    //                 uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
 
-        // update block hash
-        if reverse {
-            *current_hash = block_headers.last().unwrap().parent_hash.to_vec();
-        } else {
-            if block_headers.len() == 0 {
-                warn!("No block founds");
+    //                 code = uncrypted_body[0] - 16;
+    //                 if code == 16 {
+    //                     break;
+    //                 }
+    //             }
+    //             assert_eq!(code, 16);
 
-                // We need to go one block back
-                let mut postgres_client =
-                    postgres::Client::connect(&database_params, postgres::NoTls)
-                        .expect("to connect to database");
-                let result = postgres_client.query(format!("SELECT parent_hash, hash, number FROM {0}.blocks WHERE number = (SELECT MAX(number) FROM {0}.blocks);", network.to_string()).as_str(), &[]).unwrap();
+    //             let tmp_rpt: Vec<Vec<Receipt>> = eth::parse_receipts(uncrypted_body[1..].to_vec());
+    //             receipts.extend(tmp_rpt);
 
-                let hash: Vec<u8> = result[0].try_get(1).unwrap();
-                match result[0].try_get(0) {
-                    Ok(h) => {
-                        *current_hash = h;
-                    }
-                    Err(_) => {
-                        error!("Fail to get hash of the minimum block");
-                    }
-                }
+    //             info!(
+    //                 "Handling Receipts message ({}/{} block receipts received)",
+    //                 receipts.len(),
+    //                 hashes.len()
+    //             );
+    //         }
+    //     }
 
-                // Delete the block we cannot find anymore
-                info!(
-                    "Deleting block {} on network {}",
-                    hex::encode(&hash),
-                    network.to_string()
-                );
-                postgres_client.batch_execute(format!("DELETE FROM {0}.transactions WHERE block = '\\x{1}'; DELETE FROM {0}.blocks WHERE hash = '\\x{1}';", network.to_string(), hex::encode(&hash)).as_str()).unwrap();
+    // let mut blocks: Vec<(
+    //     Block,
+    //     Vec<Transaction>,
+    //     Vec<Block>,
+    //     Vec<Withdrawal>,
+    //     Vec<Receipt>,
+    // )> = vec![];
+    // let t_iter = transactions.iter();
+    // t_iter
+    //     .enumerate()
+    //     .for_each(|(i, (txs, ommers, withdrawals))| {
+    //         blocks.push((
+    //             block_headers[i].clone(),
+    //             txs.to_owned(),
+    //             ommers.to_owned(),
+    //             withdrawals.to_owned(),
+    //             if version == 69 {
+    //                 receipts[i].clone()
+    //             } else {
+    //                 vec![]
+    //             },
+    //         ));
+    //     });
 
-                continue;
-            }
+    //     let current_height = blocks.last().unwrap().0.number;
+    //     info!("Blocks n° {}", current_height);
 
-            let last_block = block_headers.last().unwrap();
+    //     // We already have the first block of the current batch when toward the tip of the chain
+    //     if !reverse {
+    //         blocks.remove(0);
+    //     }
 
-            // Verify if the block has ben created less than 600 seconds ago (1hr). Blocks are being created every 15 seconds.
-            if SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as u32
-                - last_block.time
-                < 600
-            {
-                trace!("We have the latest created block. Waiting 15 seconds.");
-                tokio::time::sleep(Duration::from_secs(15)).await;
-            } else {
-                // if the last block is older than 1hr we are assuming the node is not receiving new blocks
-                if current_hash.as_slice() == last_block.hash.as_slice() {
-                    warn!("Last block is our current block");
-                    return Err("No new blocks".into());
-                }
-            }
+    //     // send blocks to the other thread to save in database
+    //     if blocks.len() > 0 {
+    //         tx.send(blocks).await?;
+    //     }
 
-            *current_hash = last_block.hash.to_vec();
-        }
+    //     if current_height == 0 {
+    //         info!("Data fully synced");
 
-        /******************
-         *
-         *  Send GetBlockBodies message
-         *
-         ******************/
-        info!("Sending GetBlockBodies message");
-        let hashes = block_headers
-            .iter()
-            .map(|b| b.hash.clone())
-            .collect::<Vec<Vec<u8>>>();
+    //         drop(tcp_handle);
 
-        let mut transactions: Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> = vec![];
+    //         break;
+    //     }
+    // }
 
-        while transactions.len() < hashes.len() {
-            let get_blocks_bodies =
-                eth::create_get_block_bodies_message(&hashes[transactions.len()..].to_vec());
-            utils::send_message(get_blocks_bodies, &stream, &egress_mac, &egress_aes).await?;
-
-            /******************
-             *
-             *  Handle BlockHeader message
-             *
-             ******************/
-
-            let mut uncrypted_body: Vec<u8>;
-            let mut code;
-            loop {
-                uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
-
-                code = uncrypted_body[0] - 16;
-                if code == 6 {
-                    break;
-                }
-            }
-            assert_eq!(code, 6);
-
-            let tmp_txs = eth::parse_block_bodies(uncrypted_body[1..].to_vec());
-            transactions.extend(tmp_txs);
-
-            info!(
-                "Handling BlockBodies message ({}/{} block bodies received)",
-                transactions.len(),
-                hashes.len()
-            );
-        }
-
-        /******************
-         *
-         *  Send GetReceipts message
-         *
-         ******************/
-
-        // TODO: implement ETH 69 to be able to get receipts. Older protocols support it but are more of a struggle to implement.
-        info!("Sending GetReceipts message");
-        let mut receipts: Vec<Vec<Receipt>> = vec![];
-
-        if version == 69 {
-            while receipts.len() < hashes.len() {
-                let get_receipts =
-                    eth::create_get_receipts_message(&hashes[receipts.len()..].to_vec());
-                utils::send_message(get_receipts, &stream, &egress_mac, &egress_aes).await?;
-
-                /******************
-                 *
-                 *  Handle Receipts message
-                 *
-                 ******************/
-
-                let mut uncrypted_body: Vec<u8>;
-                let mut code;
-                loop {
-                    uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
-
-                    code = uncrypted_body[0] - 16;
-                    if code == 16 {
-                        break;
-                    }
-                }
-                assert_eq!(code, 16);
-
-                let tmp_rpt: Vec<Vec<Receipt>> = eth::parse_receipts(uncrypted_body[1..].to_vec());
-                receipts.extend(tmp_rpt);
-
-                info!(
-                    "Handling Receipts message ({}/{} block receipts received)",
-                    receipts.len(),
-                    hashes.len()
-                );
-            }
-        }
-
-        let mut blocks: Vec<(
-            Block,
-            Vec<Transaction>,
-            Vec<Block>,
-            Vec<Withdrawal>,
-            Vec<Receipt>,
-        )> = vec![];
-        let t_iter = transactions.iter();
-        t_iter
-            .enumerate()
-            .for_each(|(i, (txs, ommers, withdrawals))| {
-                blocks.push((
-                    block_headers[i].clone(),
-                    txs.to_owned(),
-                    ommers.to_owned(),
-                    withdrawals.to_owned(),
-                    if version == 69 {
-                        receipts[i].clone()
-                    } else {
-                        vec![]
-                    },
-                ));
-            });
-
-        let current_height = blocks.last().unwrap().0.number;
-        info!("Blocks n° {}", current_height);
-
-        // We already have the first block of the current batch when toward the tip of the chain
-        if !reverse {
-            blocks.remove(0);
-        }
-
-        // send blocks to the other thread to save in database
-        if blocks.len() > 0 {
-            tx.send(blocks).await?;
-        }
-
-        if current_height == 0 {
-            info!("Data fully synced");
-
-            drop(tcp_handle);
-
-            break;
-        }
-    }
+    let _ = connection.handle.await;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,15 +5,13 @@ use secp256k1::{rand, SecretKey};
 use std::env;
 use std::error;
 use std::net::SocketAddr;
-use std::net::TcpStream;
 use std::str::FromStr;
-use std::sync::mpsc::SyncSender;
-use std::sync::mpsc::{channel, sync_channel};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::thread::{self, sleep};
+use std::thread;
 use std::time::Duration;
 use std::time::SystemTime;
+use tokio::net::TcpStream;
 
 use eth_prototype::eth;
 use eth_prototype::types::{Block, Receipt, Transaction, Withdrawal};
@@ -125,7 +123,15 @@ fn main() {
      ********************/
 
     // Create a queue with a maximum of 102400 blocks (100 * 1024 = 102400 blocks). We query blocks by batch of 1024 blocks.
-    let (tx, rx) = sync_channel(100);
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<
+        Vec<(
+            Block,
+            Vec<Transaction>,
+            Vec<Block>,
+            Vec<Withdrawal>,
+            Vec<Receipt>,
+        )>,
+    >(100);
 
     let db_params = database_params.clone();
     let database_handle = thread::spawn(move || {
@@ -142,7 +148,7 @@ fn main() {
                 Vec<Block>,
                 Vec<Withdrawal>,
                 Vec<Receipt>,
-            )> = rx.recv().unwrap();
+            )> = rx.blocking_recv().unwrap();
             database::save_blocks(&blocks, &network_arg, &mut postgres_client);
 
             // We are synced
@@ -157,38 +163,44 @@ fn main() {
         info!("Closing thread!");
     });
 
-    for peer in config.peers {
-        match run(
-            peer,
-            network,
-            &database_params,
-            &mut current_hash,
-            reverse,
-            &tx,
-        ) {
-            Ok(()) => {
-                // We are done
-                break;
-            }
-            Err(_) => {
-                // next peer
-                continue;
-            }
-        };
-    }
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        for peer in config.peers {
+            match run(
+                peer,
+                network,
+                &database_params,
+                &mut current_hash,
+                reverse,
+                &tx,
+            )
+            .await
+            {
+                Ok(()) => {
+                    // We are done
+                    break;
+                }
+                Err(_) => {
+                    // next peer
+                    continue;
+                }
+            };
+        }
 
-    info!("Tried all peers");
+        info!("Tried all peers");
+    });
+
     // need to wait for database thread to finish
     database_handle.join().unwrap();
 }
 
-fn run(
+async fn run(
     peer: Peer,
     network: Network,
     database_params: &String,
     current_hash: &mut Vec<u8>,
     reverse: bool,
-    tx: &SyncSender<
+    tx: &tokio::sync::mpsc::Sender<
         Vec<(
             Block,
             Vec<Transaction>,
@@ -203,11 +215,11 @@ fn run(
      *  Connect to peer
      *
      ******************/
-    let mut stream = TcpStream::connect_timeout(
-        &SocketAddr::from_str(&format!("{}:{}", peer.ip, peer.port)).unwrap(),
+    let mut stream = tokio::time::timeout(
         Duration::from_secs(3),
-    )?;
-    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+        TcpStream::connect(SocketAddr::from_str(&format!("{}:{}", peer.ip, peer.port)).unwrap()),
+    )
+    .await??;
 
     let private_key = SecretKey::new(&mut rand::thread_rng())
         .secret_bytes()
@@ -235,10 +247,10 @@ fn run(
 
     // send the message
     info!("Sending EIP8 Auth message");
-    utils::send_eip8_auth_message(&init_msg, &mut stream)?;
+    utils::send_eip8_auth_message(&init_msg, &mut stream).await?;
 
     info!("waiting for answer... (ACK message)");
-    let (payload, shared_mac_data) = utils::read_ack_message(&mut stream)?;
+    let (payload, shared_mac_data) = utils::read_ack_message(&mut stream).await?;
 
     /******************
      *
@@ -269,8 +281,9 @@ fn run(
         remote_data,
         init_msg,
     );
-    let mut egress_aes = Arc::new(Mutex::new(egress_aes));
-    let mut egress_mac = Arc::new(Mutex::new(egress_mac));
+    let egress_aes = Arc::new(Mutex::new(egress_aes));
+    let egress_mac = Arc::new(Mutex::new(egress_mac));
+    let stream = Arc::new(tokio::sync::Mutex::new(stream));
 
     info!("Frame setup done !");
 
@@ -282,7 +295,7 @@ fn run(
      *
      ******************/
 
-    let uncrypted_body = utils::read_message(&mut stream, &mut ingress_mac, &mut ingress_aes)?;
+    let uncrypted_body = utils::read_message(&stream, &mut ingress_mac, &mut ingress_aes).await?;
 
     if uncrypted_body[0] == 0x01 {
         warn!("Disconnect message : {}", hex::encode(&uncrypted_body));
@@ -331,7 +344,7 @@ fn run(
             .to_vec(),
     };
     let hello = message::create_hello_message(hello_message);
-    utils::send_message(hello, &mut stream, &mut egress_mac, &mut egress_aes)?;
+    utils::send_message(hello, &stream, &egress_mac, &egress_aes).await?;
 
     /******************
      *
@@ -370,7 +383,7 @@ fn run(
         };
         payload = eth::create_status_message(status);
     }
-    utils::send_message(payload, &mut stream, &mut egress_mac, &mut egress_aes)?;
+    utils::send_message(payload, &stream, &egress_mac, &egress_aes).await?;
 
     /******************
      *
@@ -379,7 +392,7 @@ fn run(
      ******************/
 
     info!("Handling STATUS message");
-    let uncrypted_body = utils::read_message(&mut stream, &mut ingress_mac, &mut ingress_aes)?;
+    let uncrypted_body = utils::read_message(&stream, &mut ingress_mac, &mut ingress_aes).await?;
     if uncrypted_body[0] == 0x01 {
         warn!("Disconnect message : {}", hex::encode(&uncrypted_body));
 
@@ -422,12 +435,7 @@ fn run(
      ******************/
     if network == networks::Network::BINANCE_MAINNET {
         let upgrade_status = eth::create_upgrade_status_message();
-        utils::send_message(
-            upgrade_status,
-            &mut stream,
-            &mut egress_mac,
-            &mut egress_aes,
-        )?;
+        utils::send_message(upgrade_status, &stream, &egress_mac, &egress_aes).await?;
     }
 
     // If we are already synced and we are saving new blocks, lets verify that we don't have the already highest block from this peer.
@@ -465,18 +473,19 @@ fn run(
      *
      ****************************/
 
-    let mut thread_stream = stream.try_clone().unwrap();
+    let thread_stream = Arc::clone(&stream);
     let thread_egress_mac = Arc::clone(&egress_mac);
     let thread_egress_aes = Arc::clone(&egress_aes);
 
-    let (tx_tcp, rx_tcp) = channel();
+    let (tx_tcp, mut rx_tcp) = tokio::sync::mpsc::channel::<Vec<u8>>(32);
 
-    let tcp_handle = thread::spawn(move || {
+    let tcp_handle = tokio::spawn(async move {
         let mut uncrypted_body: Vec<u8>;
         let mut code;
         loop {
             uncrypted_body =
-                utils::read_message(&mut thread_stream, &mut ingress_mac, &mut ingress_aes)
+                utils::read_message(&thread_stream, &mut ingress_mac, &mut ingress_aes)
+                    .await
                     .unwrap();
 
             // handle RLPx message
@@ -489,10 +498,11 @@ fn run(
 
                     utils::send_message(
                         pong,
-                        &mut thread_stream,
+                        &thread_stream,
                         &thread_egress_mac,
                         &thread_egress_aes,
                     )
+                    .await
                     .unwrap();
 
                     continue;
@@ -531,14 +541,15 @@ fn run(
 
                 utils::send_message(
                     empty_block_bodies_message,
-                    &mut thread_stream,
+                    &thread_stream,
                     &thread_egress_mac,
                     &thread_egress_aes,
                 )
+                .await
                 .unwrap();
             }
 
-            if tx_tcp.send(uncrypted_body).is_err() {
+            if tx_tcp.send(uncrypted_body).await.is_err() {
                 break;
             }
         }
@@ -558,12 +569,7 @@ fn run(
 
         let get_blocks_headers =
             eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, reverse);
-        utils::send_message(
-            get_blocks_headers,
-            &mut stream,
-            &mut egress_mac,
-            &mut egress_aes,
-        )?;
+        utils::send_message(get_blocks_headers, &stream, &egress_mac, &egress_aes).await?;
 
         /******************
          *
@@ -575,7 +581,7 @@ fn run(
         let mut uncrypted_body: Vec<u8>;
         let mut code;
         loop {
-            uncrypted_body = rx_tcp.recv()?;
+            uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
 
             code = uncrypted_body[0] - 16;
             if code == 4 {
@@ -632,7 +638,7 @@ fn run(
                 < 600
             {
                 trace!("We have the latest created block. Waiting 15 seconds.");
-                sleep(Duration::from_secs(15));
+                tokio::time::sleep(Duration::from_secs(15)).await;
             } else {
                 // if the last block is older than 1hr we are assuming the node is not receiving new blocks
                 if current_hash.as_slice() == last_block.hash.as_slice() {
@@ -660,12 +666,7 @@ fn run(
         while transactions.len() < hashes.len() {
             let get_blocks_bodies =
                 eth::create_get_block_bodies_message(&hashes[transactions.len()..].to_vec());
-            utils::send_message(
-                get_blocks_bodies,
-                &mut stream,
-                &mut egress_mac,
-                &mut egress_aes,
-            )?;
+            utils::send_message(get_blocks_bodies, &stream, &egress_mac, &egress_aes).await?;
 
             /******************
              *
@@ -676,7 +677,7 @@ fn run(
             let mut uncrypted_body: Vec<u8>;
             let mut code;
             loop {
-                uncrypted_body = rx_tcp.recv()?;
+                uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
 
                 code = uncrypted_body[0] - 16;
                 if code == 6 {
@@ -709,7 +710,7 @@ fn run(
             while receipts.len() < hashes.len() {
                 let get_receipts =
                     eth::create_get_receipts_message(&hashes[receipts.len()..].to_vec());
-                utils::send_message(get_receipts, &mut stream, &mut egress_mac, &mut egress_aes)?;
+                utils::send_message(get_receipts, &stream, &egress_mac, &egress_aes).await?;
 
                 /******************
                  *
@@ -720,7 +721,7 @@ fn run(
                 let mut uncrypted_body: Vec<u8>;
                 let mut code;
                 loop {
-                    uncrypted_body = rx_tcp.recv()?;
+                    uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
 
                     code = uncrypted_body[0] - 16;
                     if code == 16 {
@@ -774,7 +775,7 @@ fn run(
 
         // send blocks to the other thread to save in database
         if blocks.len() > 0 {
-            tx.send(blocks)?;
+            tx.send(blocks).await?;
         }
 
         if current_height == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,11 @@ fn main() {
         )>,
     >(100);
 
+    // Shared between DB thread and forward sync: last block number + hash confirmed saved.
+    let last_confirmed: Arc<std::sync::Mutex<Option<(u32, Vec<u8>)>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let last_confirmed_db = last_confirmed.clone();
+
     let db_params = database_params.clone();
     let database_handle = thread::spawn(move || {
         info!("Starting database thread");
@@ -170,6 +175,8 @@ fn main() {
                 database::save_blocks(&batch, &network_arg, &mut postgres_client);
                 let last = batch.last().unwrap().0.number;
                 last_block_number = Some(last);
+                *last_confirmed_db.lock().unwrap() =
+                    Some((last, batch.last().unwrap().0.hash.clone()));
 
                 if network.genesis_hash.to_vec() == batch.last().unwrap().0.hash.to_vec() {
                     info!("We are synced ! We are creating the indexes on the tables... This will take a while.");
@@ -552,6 +559,34 @@ fn main() {
                         pool.push_back(conn);
                         tokio::time::sleep(Duration::from_secs(15)).await;
                         continue;
+                    }
+
+                    // Detect gap: if we're fetching blocks that are ahead of what the DB
+                    // has actually saved, a prior batch was lost (dropped connection, failed
+                    // retry, etc.). Reset current_hash to the last confirmed save so the
+                    // missing blocks are re-fetched.
+                    let reset_to = {
+                        let guard = last_confirmed.lock().unwrap();
+                        if let Some((confirmed_num, ref confirmed_hash)) = *guard {
+                            let new_first = new_headers.first().unwrap().number;
+                            if new_first > confirmed_num + 1 {
+                                Some((confirmed_num, confirmed_hash.clone()))
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    };
+                    if let Some((confirmed_num, confirmed_hash)) = reset_to {
+                        warn!(
+                            "Gap detected: next block is {} but DB last confirmed {}. Resetting current_hash.",
+                            new_headers.first().unwrap().number,
+                            confirmed_num
+                        );
+                        current_hash = confirmed_hash;
+                        pool.push_back(conn);
+                        continue 'outer;
                     }
 
                     current_hash = new_headers.last().unwrap().hash.to_vec();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,3 @@
-use eth_prototype::configs::Peer;
-use eth_prototype::networks::Network;
-use rand::Rng;
-use secp256k1::rand::RngCore;
 use secp256k1::{rand, SecretKey};
 use std::collections::VecDeque;
 use std::env;
@@ -257,19 +253,25 @@ fn main() {
             // Sometimes peers are stuck and don't have new blocks. We need to disconnect from those.
             if !reverse {
                 // We need to go one block back
-                let mut postgres_client =
-                    postgres::Client::connect(&database_params, postgres::NoTls)
+                let (pg_client, pg_conn) =
+                    tokio_postgres::connect(&database_params, tokio_postgres::NoTls)
+                        .await
                         .expect("to connect to database");
-                let result = postgres_client
+                tokio::spawn(async move {
+                    if let Err(e) = pg_conn.await {
+                        warn!("postgres connection error: {}", e);
+                    }
+                });
+                let result = pg_client
                     .query(
-                        format!(
+                        &format!(
                             "SELECT * FROM {0}.blocks WHERE hash = '\\x{1}';",
                             network.to_string(),
                             hex::encode(&best_hash)
-                        )
-                        .as_str(),
+                        ),
                         &[],
                     )
+                    .await
                     .unwrap();
 
                 if result.len() > 0 {
@@ -283,100 +285,246 @@ fn main() {
             }
         }
 
-        // Fetch blocks - pipeline header requests across connections while
-        // bodies/receipts are fetched concurrently in spawned tasks.
-        // Tasks return Ok(conn) on success or Err(block_headers) so the batch
-        // can be retried on a different connection.
-        let done = Arc::new(AtomicBool::new(false));
         let mut pool: VecDeque<Connection> = connections.into_iter().collect();
-        let mut body_tasks: JoinSet<Result<Connection, Vec<Block>>> = JoinSet::new();
-        let mut retry_queue: VecDeque<Vec<Block>> = VecDeque::new();
 
-        'outer: loop {
-            if done.load(Ordering::Relaxed) {
-                break;
-            }
+        if reverse {
+            // Reverse sync (tip → genesis): pipeline header requests across
+            // connections while bodies/receipts are fetched concurrently.
+            // Tasks return Ok(conn) on success or Err(block_headers) so the
+            // batch can be retried on a different connection.
+            let done = Arc::new(AtomicBool::new(false));
+            let mut body_tasks: JoinSet<Result<Connection, Vec<Block>>> = JoinSet::new();
+            let mut retry_queue: VecDeque<Vec<Block>> = VecDeque::new();
 
-            // Get an available connection; if the pool is empty wait for a
-            // body task to finish and reclaim its connection (or a retry batch).
-            let mut conn = loop {
-                if let Some(c) = pool.pop_front() {
-                    break c;
-                }
-                match body_tasks.join_next().await {
-                    Some(Ok(Ok(c))) => pool.push_back(c),
-                    Some(Ok(Err(headers))) => {
-                        warn!("Task failed, re-queuing batch of {} headers", headers.len());
-                        retry_queue.push_back(headers);
-                    }
-                    Some(Err(e)) => warn!("Body task panicked: {:?}", e),
-                    None => {
-                        warn!("No connections left");
-                        break 'outer;
-                    }
-                }
-            };
-
-            // Use a pending retry batch or fetch new headers from the peer.
-            let block_headers = if let Some(headers) = retry_queue.pop_front() {
-                info!(
-                    "Retrying batch of {} headers on new connection",
-                    headers.len()
-                );
-                headers
-            } else {
-                // Send GetBlockHeaders
-                info!(
-                    "Sending GetBlockHeaders (starting {})",
-                    hex::encode(&current_hash)
-                );
-                let get_headers =
-                    eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, reverse);
-                if conn.tx_write.send(get_headers).await.is_err() {
-                    warn!("Connection lost, dropping");
-                    continue;
-                }
-
-                // Wait for BlockHeaders (code 4)
-                let headers_body = loop {
-                    match conn.rx_tcp.recv().await {
-                        Some(body) if body[0].saturating_sub(16) == 4 => break Some(body),
-                        Some(_) => continue,
-                        None => break None,
-                    }
-                };
-                let headers_body = match headers_body {
-                    Some(b) => b,
-                    None => continue,
-                };
-
-                let headers = eth::parse_block_headers(headers_body[1..].to_vec());
-                if headers.is_empty() {
-                    warn!("No block headers received");
-                    pool.push_back(conn);
+            'outer: loop {
+                if done.load(Ordering::Relaxed) {
                     break;
                 }
 
-                // Update current_hash before spawning so the next iteration
-                // immediately starts fetching the following batch.
-                if reverse {
-                    current_hash = headers.last().unwrap().parent_hash.to_vec();
+                // Get an available connection; if the pool is empty wait for a
+                // body task to finish and reclaim its connection (or a retry batch).
+                let mut conn = loop {
+                    if let Some(c) = pool.pop_front() {
+                        break c;
+                    }
+                    match body_tasks.join_next().await {
+                        Some(Ok(Ok(c))) => pool.push_back(c),
+                        Some(Ok(Err(headers))) => {
+                            warn!("Task failed, re-queuing batch of {} headers", headers.len());
+                            retry_queue.push_back(headers);
+                        }
+                        Some(Err(e)) => warn!("Body task panicked: {:?}", e),
+                        None => {
+                            warn!("No connections left");
+                            break 'outer;
+                        }
+                    }
+                };
+
+                let block_headers = if let Some(headers) = retry_queue.pop_front() {
+                    info!("Retrying batch of {} headers on new connection", headers.len());
+                    headers
                 } else {
+                    info!("Sending GetBlockHeaders (starting {})", hex::encode(&current_hash));
+                    let get_headers =
+                        eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, true);
+                    if conn.tx_write.send(get_headers).await.is_err() {
+                        warn!("Connection lost, dropping");
+                        continue;
+                    }
+
+                    let headers_body = loop {
+                        match conn.rx_tcp.recv().await {
+                            Some(body) if body[0].saturating_sub(16) == 4 => break Some(body),
+                            Some(_) => continue,
+                            None => break None,
+                        }
+                    };
+                    let headers_body = match headers_body {
+                        Some(b) => b,
+                        None => continue,
+                    };
+
+                    let headers = eth::parse_block_headers(headers_body[1..].to_vec());
+                    if headers.is_empty() {
+                        warn!("No block headers received");
+                        pool.push_back(conn);
+                        break;
+                    }
+
+                    current_hash = headers.last().unwrap().parent_hash.to_vec();
+                    headers
+                };
+
+                let tx_clone = tx.clone();
+                let done_clone = done.clone();
+                body_tasks.spawn(async move {
+                    let mut conn = conn;
+                    let hashes: Vec<Vec<u8>> =
+                        block_headers.iter().map(|b| b.hash.clone()).collect();
+                    let eth_version = conn.eth_protocol_version;
+
+                    let mut transactions: Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> =
+                        vec![];
+                    while transactions.len() < hashes.len() {
+                        info!(
+                            "Sending GetBlockBodies ({}/{})",
+                            transactions.len(),
+                            hashes.len()
+                        );
+                        let get_bodies = eth::create_get_block_bodies_message(
+                            &hashes[transactions.len()..].to_vec(),
+                        );
+                        if conn.tx_write.send(get_bodies).await.is_err() {
+                            warn!("Connection lost during GetBlockBodies, will retry batch");
+                            return Err(block_headers);
+                        }
+                        loop {
+                            match conn.rx_tcp.recv().await {
+                                Some(body) if body[0].saturating_sub(16) == 6 => {
+                                    transactions
+                                        .extend(eth::parse_block_bodies(body[1..].to_vec()));
+                                    break;
+                                }
+                                Some(_) => continue,
+                                None => {
+                                    warn!(
+                                        "Connection closed during GetBlockBodies, will retry batch"
+                                    );
+                                    return Err(block_headers);
+                                }
+                            }
+                        }
+                    }
+
+                    let mut receipts: Vec<Vec<Receipt>> = vec![];
+                    if eth_version == 69 {
+                        while receipts.len() < hashes.len() {
+                            info!(
+                                "Sending GetReceipts ({}/{})",
+                                receipts.len(),
+                                hashes.len()
+                            );
+                            let get_receipts = eth::create_get_receipts_message(
+                                &hashes[receipts.len()..].to_vec(),
+                            );
+                            if conn.tx_write.send(get_receipts).await.is_err() {
+                                warn!("Connection lost during GetReceipts, will retry batch");
+                                return Err(block_headers);
+                            }
+                            loop {
+                                match conn.rx_tcp.recv().await {
+                                    Some(body) if body[0].saturating_sub(16) == 16 => {
+                                        receipts.extend(eth::parse_receipts(body[1..].to_vec()));
+                                        break;
+                                    }
+                                    Some(_) => continue,
+                                    None => {
+                                        warn!("Connection closed during GetReceipts, will retry batch");
+                                        return Err(block_headers);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    let blocks: Vec<_> = block_headers
+                        .iter()
+                        .enumerate()
+                        .map(|(i, header)| {
+                            let (txs, ommers, withdrawals) = transactions[i].clone();
+                            let block_receipts =
+                                if eth_version == 69 { receipts[i].clone() } else { vec![] };
+                            (header.clone(), txs, ommers, withdrawals, block_receipts)
+                        })
+                        .collect();
+
+                    let current_height = blocks.last().unwrap().0.number;
+                    info!("Blocks n° {}", current_height);
+
+                    if tx_clone.send(blocks).await.is_err() {
+                        warn!("DB channel closed");
+                        return Err(block_headers);
+                    }
+
+                    if current_height == 0 {
+                        info!("Data fully synced");
+                        done_clone.store(true, Ordering::Relaxed);
+                        return Ok(conn);
+                    }
+
+                    Ok(conn)
+                });
+            }
+
+            while body_tasks.join_next().await.is_some() {}
+        } else {
+            // Forward sync (tracking the tip): sequential, one batch at a time,
+            // rotating through peers. No parallelism needed since new blocks
+            // arrive slowly (~12s apart).
+            let mut retry_headers: Option<Vec<Block>> = None;
+
+            'outer: loop {
+                let mut conn = match pool.pop_front() {
+                    Some(c) => c,
+                    None => {
+                        warn!("No connections left");
+                        break;
+                    }
+                };
+
+                let block_headers = if let Some(headers) = retry_headers.take() {
+                    info!("Retrying batch of {} headers on new connection", headers.len());
+                    headers
+                } else {
+                    info!("Sending GetBlockHeaders (starting {})", hex::encode(&current_hash));
+                    let get_headers =
+                        eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, false);
+                    if conn.tx_write.send(get_headers).await.is_err() {
+                        warn!("Connection lost, dropping");
+                        continue;
+                    }
+
+                    let headers_body = loop {
+                        match conn.rx_tcp.recv().await {
+                            Some(body) if body[0].saturating_sub(16) == 4 => break Some(body),
+                            Some(_) => continue,
+                            None => break None,
+                        }
+                    };
+                    let headers_body = match headers_body {
+                        Some(b) => b,
+                        None => continue,
+                    };
+
+                    let headers = eth::parse_block_headers(headers_body[1..].to_vec());
+                    if headers.is_empty() {
+                        warn!("No new block headers, waiting...");
+                        pool.push_back(conn);
+                        tokio::time::sleep(Duration::from_secs(15)).await;
+                        continue;
+                    }
+
+                    // Skip the first header: it's current_hash, which is
+                    // already in the DB. The peer returns it inclusive.
+                    let headers: Vec<Block> = headers.into_iter().skip(1).collect();
+                    if headers.is_empty() {
+                        warn!("No new block headers, waiting...");
+                        pool.push_back(conn);
+                        tokio::time::sleep(Duration::from_secs(15)).await;
+                        continue;
+                    }
+
                     current_hash = headers.last().unwrap().hash.to_vec();
-                }
+                    headers
+                };
 
-                headers
-            };
-
-            let tx_clone = tx.clone();
-            let done_clone = done.clone();
-            body_tasks.spawn(async move {
-                let mut conn = conn;
-                let hashes: Vec<Vec<u8>> = block_headers.iter().map(|b| b.hash.clone()).collect();
+                let hashes: Vec<Vec<u8>> =
+                    block_headers.iter().map(|b| b.hash.clone()).collect();
                 let eth_version = conn.eth_protocol_version;
 
-                // Fetch block bodies
-                let mut transactions: Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> = vec![];
+                let mut transactions: Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> =
+                    vec![];
                 while transactions.len() < hashes.len() {
                     info!(
                         "Sending GetBlockBodies ({}/{})",
@@ -388,7 +536,8 @@ fn main() {
                     );
                     if conn.tx_write.send(get_bodies).await.is_err() {
                         warn!("Connection lost during GetBlockBodies, will retry batch");
-                        return Err(block_headers);
+                        retry_headers = Some(block_headers);
+                        continue 'outer;
                     }
                     loop {
                         match conn.rx_tcp.recv().await {
@@ -399,22 +548,24 @@ fn main() {
                             Some(_) => continue,
                             None => {
                                 warn!("Connection closed during GetBlockBodies, will retry batch");
-                                return Err(block_headers);
+                                retry_headers = Some(block_headers);
+                                continue 'outer;
                             }
                         }
                     }
                 }
 
-                // Fetch receipts (eth69 only)
                 let mut receipts: Vec<Vec<Receipt>> = vec![];
                 if eth_version == 69 {
                     while receipts.len() < hashes.len() {
                         info!("Sending GetReceipts ({}/{})", receipts.len(), hashes.len());
-                        let get_receipts =
-                            eth::create_get_receipts_message(&hashes[receipts.len()..].to_vec());
+                        let get_receipts = eth::create_get_receipts_message(
+                            &hashes[receipts.len()..].to_vec(),
+                        );
                         if conn.tx_write.send(get_receipts).await.is_err() {
                             warn!("Connection lost during GetReceipts, will retry batch");
-                            return Err(block_headers);
+                            retry_headers = Some(block_headers);
+                            continue 'outer;
                         }
                         loop {
                             match conn.rx_tcp.recv().await {
@@ -425,7 +576,8 @@ fn main() {
                                 Some(_) => continue,
                                 None => {
                                     warn!("Connection closed during GetReceipts, will retry batch");
-                                    return Err(block_headers);
+                                    retry_headers = Some(block_headers);
+                                    continue 'outer;
                                 }
                             }
                         }
@@ -437,11 +589,8 @@ fn main() {
                     .enumerate()
                     .map(|(i, header)| {
                         let (txs, ommers, withdrawals) = transactions[i].clone();
-                        let block_receipts = if eth_version == 69 {
-                            receipts[i].clone()
-                        } else {
-                            vec![]
-                        };
+                        let block_receipts =
+                            if eth_version == 69 { receipts[i].clone() } else { vec![] };
                         (header.clone(), txs, ommers, withdrawals, block_receipts)
                     })
                     .collect();
@@ -449,312 +598,16 @@ fn main() {
                 let current_height = blocks.last().unwrap().0.number;
                 info!("Blocks n° {}", current_height);
 
-                if tx_clone.send(blocks).await.is_err() {
+                if tx.send(blocks).await.is_err() {
                     warn!("DB channel closed");
-                    return Err(block_headers);
+                    break;
                 }
 
-                if current_height == 0 {
-                    info!("Data fully synced");
-                    done_clone.store(true, Ordering::Relaxed);
-                    return Ok(conn);
-                }
-
-                Ok(conn)
-            });
+                pool.push_back(conn);
+            }
         }
-
-        // Drain remaining body tasks before exiting
-        while body_tasks.join_next().await.is_some() {}
     });
 
     // need to wait for database thread to finish
     database_handle.join().unwrap();
-}
-
-async fn run(
-    peer: Peer,
-    network: Network,
-    database_params: &String,
-    current_hash: &mut Vec<u8>,
-    reverse: bool,
-    tx: &tokio::sync::mpsc::Sender<
-        Vec<(
-            Block,
-            Vec<Transaction>,
-            Vec<Block>,
-            Vec<Withdrawal>,
-            Vec<Receipt>,
-        )>,
-    >,
-) -> Result<(), Box<dyn error::Error + Send + Sync>> {
-    // Connect to the peer
-    let connection = Connection::connect(peer, network).await?;
-    let their_blockhash = connection.latest_blockhash();
-
-    // If we are already synced and we are saving new blocks, lets verify that we don't have the already highest block from this peer.
-    // Sometimes peers are stuck and don't have new blocks. We need to disconnect from those.
-    if !reverse {
-        // We need to go one block back
-        let mut postgres_client = postgres::Client::connect(&database_params, postgres::NoTls)
-            .expect("to connect to database");
-        let result = postgres_client
-            .query(
-                format!(
-                    "SELECT * FROM {0}.blocks WHERE hash = '\\x{1}';",
-                    network.to_string(),
-                    hex::encode(their_blockhash)
-                )
-                .as_str(),
-                &[],
-            )
-            .unwrap();
-
-        if result.len() > 0 {
-            warn!("We already have their latets block");
-            return Err("Peer not synced".into());
-        }
-    }
-
-    // If we don't have blocks in the database we use the best one
-    if current_hash.len() == 0 {
-        *current_hash = connection.latest_blockhash().clone();
-    }
-
-    /****************************
-     *
-     *  START FETCHING BLOCKS
-     *
-     ****************************/
-
-    // loop {
-    //     /******************
-    //      *
-    //      *  Send GetBlockHeaders message
-    //      *
-    //      ******************/
-    //     info!(
-    //         "Sending GetBlockHeaders message (starting {})",
-    //         hex::encode(&current_hash)
-    //     );
-
-    //     let get_blocks_headers =
-    //         eth::create_get_block_headers_message(&current_hash, BLOCK_NUM, 0, reverse);
-    //     utils::send_message(get_blocks_headers, &stream, &egress_mac, &egress_aes).await?;
-
-    //     /******************
-    //      *
-    //      *  Handle BlockHeader message
-    //      *
-    //      ******************/
-    //     info!("Handling BlockHeaders message");
-    //     let mut uncrypted_body: Vec<u8>;
-    //     let mut code;
-    //     loop {
-    //         uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
-
-    //         code = uncrypted_body[0] - 16;
-    //         if code == 4 {
-    //             break;
-    //         }
-    //     }
-
-    //     assert_eq!(code, 4);
-
-    //     let block_headers = eth::parse_block_headers(uncrypted_body[1..].to_vec());
-
-    //     // update block hash
-    //     if reverse {
-    //         *current_hash = block_headers.last().unwrap().parent_hash.to_vec();
-    //     } else {
-    //         if block_headers.len() == 0 {
-    //             warn!("No block founds");
-
-    //             // We need to go one block back
-    //             let mut postgres_client =
-    //                 postgres::Client::connect(&database_params, postgres::NoTls)
-    //                     .expect("to connect to database");
-    //             let result = postgres_client.query(format!("SELECT parent_hash, hash, number FROM {0}.blocks WHERE number = (SELECT MAX(number) FROM {0}.blocks);", network.to_string()).as_str(), &[]).unwrap();
-
-    //             let hash: Vec<u8> = result[0].try_get(1).unwrap();
-    //             match result[0].try_get(0) {
-    //                 Ok(h) => {
-    //                     *current_hash = h;
-    //                 }
-    //                 Err(_) => {
-    //                     error!("Fail to get hash of the minimum block");
-    //                 }
-    //             }
-
-    //             // Delete the block we cannot find anymore
-    //             info!(
-    //                 "Deleting block {} on network {}",
-    //                 hex::encode(&hash),
-    //                 network.to_string()
-    //             );
-    //             postgres_client.batch_execute(format!("DELETE FROM {0}.transactions WHERE block = '\\x{1}'; DELETE FROM {0}.blocks WHERE hash = '\\x{1}';", network.to_string(), hex::encode(&hash)).as_str()).unwrap();
-
-    //             continue;
-    //         }
-
-    //         let last_block = block_headers.last().unwrap();
-
-    //         // Verify if the block has ben created less than 600 seconds ago (1hr). Blocks are being created every 15 seconds.
-    //         if SystemTime::now()
-    //             .duration_since(SystemTime::UNIX_EPOCH)
-    //             .unwrap()
-    //             .as_secs() as u32
-    //             - last_block.time
-    //             < 600
-    //         {
-    //             trace!("We have the latest created block. Waiting 15 seconds.");
-    //             tokio::time::sleep(Duration::from_secs(15)).await;
-    //         } else {
-    //             // if the last block is older than 1hr we are assuming the node is not receiving new blocks
-    //             if current_hash.as_slice() == last_block.hash.as_slice() {
-    //                 warn!("Last block is our current block");
-    //                 return Err("No new blocks".into());
-    //             }
-    //         }
-
-    //         *current_hash = last_block.hash.to_vec();
-    //     }
-
-    //     /******************
-    //      *
-    //      *  Send GetBlockBodies message
-    //      *
-    //      ******************/
-    //     info!("Sending GetBlockBodies message");
-    //     let hashes = block_headers
-    //         .iter()
-    //         .map(|b| b.hash.clone())
-    //         .collect::<Vec<Vec<u8>>>();
-
-    //     let mut transactions: Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> = vec![];
-
-    //     while transactions.len() < hashes.len() {
-    //         let get_blocks_bodies =
-    //             eth::create_get_block_bodies_message(&hashes[transactions.len()..].to_vec());
-    //         utils::send_message(get_blocks_bodies, &stream, &egress_mac, &egress_aes).await?;
-
-    //         /******************
-    //          *
-    //          *  Handle BlockHeader message
-    //          *
-    //          ******************/
-    //         let mut uncrypted_body: Vec<u8>;
-    //         let mut code;
-    //         loop {
-    //             uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
-
-    //             code = uncrypted_body[0] - 16;
-    //             if code == 6 {
-    //                 break;
-    //             }
-    //         }
-    //         assert_eq!(code, 6);
-
-    //         let tmp_txs = eth::parse_block_bodies(uncrypted_body[1..].to_vec());
-    //         transactions.extend(tmp_txs);
-
-    //         info!(
-    //             "Handling BlockBodies message ({}/{} block bodies received)",
-    //             transactions.len(),
-    //             hashes.len()
-    //         );
-    //     }
-
-    //     /******************
-    //      *
-    //      *  Send GetReceipts message
-    //      *
-    //      ******************/
-    //     // TODO: implement ETH 69 to be able to get receipts. Older protocols support it but are more of a struggle to implement.
-    //     info!("Sending GetReceipts message");
-    //     let mut receipts: Vec<Vec<Receipt>> = vec![];
-
-    //     if version == 69 {
-    //         while receipts.len() < hashes.len() {
-    //             let get_receipts =
-    //                 eth::create_get_receipts_message(&hashes[receipts.len()..].to_vec());
-    //             utils::send_message(get_receipts, &stream, &egress_mac, &egress_aes).await?;
-
-    //             /******************
-    //              *
-    //              *  Handle Receipts message
-    //              *
-    //              ******************/
-    //             let mut uncrypted_body: Vec<u8>;
-    //             let mut code;
-    //             loop {
-    //                 uncrypted_body = rx_tcp.recv().await.ok_or("channel closed")?;
-
-    //                 code = uncrypted_body[0] - 16;
-    //                 if code == 16 {
-    //                     break;
-    //                 }
-    //             }
-    //             assert_eq!(code, 16);
-
-    //             let tmp_rpt: Vec<Vec<Receipt>> = eth::parse_receipts(uncrypted_body[1..].to_vec());
-    //             receipts.extend(tmp_rpt);
-
-    //             info!(
-    //                 "Handling Receipts message ({}/{} block receipts received)",
-    //                 receipts.len(),
-    //                 hashes.len()
-    //             );
-    //         }
-    //     }
-
-    // let mut blocks: Vec<(
-    //     Block,
-    //     Vec<Transaction>,
-    //     Vec<Block>,
-    //     Vec<Withdrawal>,
-    //     Vec<Receipt>,
-    // )> = vec![];
-    // let t_iter = transactions.iter();
-    // t_iter
-    //     .enumerate()
-    //     .for_each(|(i, (txs, ommers, withdrawals))| {
-    //         blocks.push((
-    //             block_headers[i].clone(),
-    //             txs.to_owned(),
-    //             ommers.to_owned(),
-    //             withdrawals.to_owned(),
-    //             if version == 69 {
-    //                 receipts[i].clone()
-    //             } else {
-    //                 vec![]
-    //             },
-    //         ));
-    //     });
-
-    //     let current_height = blocks.last().unwrap().0.number;
-    //     info!("Blocks n° {}", current_height);
-
-    //     // We already have the first block of the current batch when toward the tip of the chain
-    //     if !reverse {
-    //         blocks.remove(0);
-    //     }
-
-    //     // send blocks to the other thread to save in database
-    //     if blocks.len() > 0 {
-    //         tx.send(blocks).await?;
-    //     }
-
-    //     if current_height == 0 {
-    //         info!("Data fully synced");
-
-    //         drop(tcp_handle);
-
-    //         break;
-    //     }
-    // }
-
-    let _ = connection.handle.await;
-
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -523,7 +523,20 @@ fn main() {
                                 current_hash = parent_hash;
                             }
                             Ok(None) => {
-                                warn!("Block {} not found in DB during re-org rollback.", hex::encode(&current_hash));
+                                warn!("Block {} not found in DB during re-org rollback, resetting to max known block.", hex::encode(&current_hash));
+                                match reorg_pg_client.query_opt(
+                                    &format!("SELECT hash FROM {}.blocks WHERE number = (SELECT MAX(number) FROM {}.blocks);", schema, schema),
+                                    &[],
+                                ).await {
+                                    Ok(Some(row)) => {
+                                        current_hash = row.get(0);
+                                        warn!("Resuming from max known block: {}", hex::encode(&current_hash));
+                                    }
+                                    _ => {
+                                        warn!("No known blocks in DB, stopping forward sync.");
+                                        break 'outer;
+                                    }
+                                }
                             }
                             Err(e) => {
                                 warn!("Re-org rollback query failed: {}", e);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,24 +2,22 @@ use aes::cipher::{KeyIvInit, StreamCipher};
 use byteorder::ByteOrder;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use hmac_sha256::{Hash, HMAC};
-use num::Zero;
 use postgres::Client;
 use rand_core::{OsRng, RngCore};
 use rlp::RlpStream;
 use sha3::{Digest, Keccak256};
 use std::borrow::BorrowMut;
 use std::error;
-use std::io::prelude::*;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::thread;
 use std::time::Duration;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
 
 use super::mac;
 
 pub type Aes128Ctr64BE = ctr::Ctr64BE<aes::Aes128>;
 pub type Aes256Ctr64BE = ctr::Ctr64BE<aes::Aes256>;
-const READ_MESSAGE_TIME_MS: u64 = 5;
 
 pub fn get_sig(r: &[u8], s: &[u8]) -> Vec<u8> {
     let mut sig: Vec<u8> = vec![0; 64];
@@ -49,7 +47,7 @@ pub fn concat_kdf(key_material: Vec<u8>, key_length: usize) -> Vec<u8> {
     while counter <= reps {
         counter += 1;
         let mut tmp: Vec<u8> = vec![];
-        let _ = tmp.write_u32::<BigEndian>(counter as u32);
+        let _ = WriteBytesExt::write_u32::<BigEndian>(&mut tmp, counter as u32);
         let mut hash = Hash::new();
         hash.update(tmp);
         hash.update(&key_material);
@@ -196,7 +194,10 @@ pub fn create_auth_eip8(
 
     let overhead_length = 113;
     let mut shared_mac_data: Vec<u8> = vec![];
-    let _ = shared_mac_data.write_u16::<BigEndian>((auth_message.len() + overhead_length) as u16);
+    let _ = WriteBytesExt::write_u16::<BigEndian>(
+        &mut shared_mac_data,
+        (auth_message.len() + overhead_length) as u16,
+    );
 
     // Encrypt message
     let enrcyped_auth_message = encrypt_message(&remote_public_key, auth_message, &shared_mac_data);
@@ -340,73 +341,54 @@ pub fn create_body(
     return [body_message.to_vec(), tag].concat().to_vec();
 }
 
-pub fn send_message(
+pub async fn send_message(
     msg: Vec<u8>,
-    stream: &mut std::net::TcpStream,
+    stream: &Arc<tokio::sync::Mutex<tokio::net::TcpStream>>,
     egress_mac: &Arc<Mutex<mac::MAC>>,
     egress_aes: &Arc<Mutex<Aes256Ctr64BE>>,
 ) -> Result<(), Box<dyn error::Error>> {
-    let mut egress_aes = egress_aes.lock().unwrap(); // TODO: fix this unwrap here for the lock
-    let mut egress_mac = egress_mac.lock().unwrap();
+    // Compute header and body while holding the std::sync guards (not Send),
+    // then drop them before any .await point.
+    let (header, body) = {
+        let mut egress_aes = egress_aes.lock().unwrap();
+        let mut egress_mac = egress_mac.lock().unwrap();
+        let header = create_header(msg.len(), egress_mac.borrow_mut(), egress_aes.borrow_mut());
+        let body = create_body(msg, egress_mac.borrow_mut(), egress_aes.borrow_mut());
+        (header, body)
+    };
 
-    let header = create_header(msg.len(), egress_mac.borrow_mut(), egress_aes.borrow_mut());
-
-    stream.write(&header)?;
-    stream.flush()?;
-
-    let body = create_body(msg, egress_mac.borrow_mut(), egress_aes.borrow_mut());
-
-    stream.write(&body)?;
-    stream.flush()?;
+    let mut guard = stream.lock().await;
+    let stream = &mut *guard;
+    stream.write_all(&header).await?;
+    stream.write_all(&body).await?;
 
     Ok(())
 }
 
-pub fn read_message(
-    stream: &mut std::net::TcpStream,
+pub async fn read_message(
+    stream: &Arc<tokio::sync::Mutex<tokio::net::TcpStream>>,
     ingress_mac: &mut mac::MAC,
     ingress_aes: &mut Aes256Ctr64BE,
 ) -> Result<Vec<u8>, Box<dyn error::Error>> {
+    let mut guard = stream.lock().await;
+    let stream = &mut *guard;
+
     let mut buf = [0u8; 32];
+    let _ = tokio::time::timeout(Duration::from_secs(30), stream.read_exact(&mut buf)).await?;
 
-    let mut timeout: u64 = 1000; // 1sec timeout
-    while let Err(_) = stream.read_exact(&mut buf) {
-        thread::sleep(Duration::from_millis(READ_MESSAGE_TIME_MS));
-        timeout -= READ_MESSAGE_TIME_MS;
-
-        if timeout.is_zero() {
-            return Err("Timeout getting message header".into());
-        }
-    }
+    assert_eq!(buf.len(), 32);
 
     let next_size = parse_header(&buf.to_vec(), ingress_mac, ingress_aes);
-
-    // Message payload
-    let mut body: Vec<u8> = vec![];
     let body_size = get_body_len(next_size);
 
-    // we have this loop to be sure we have received the complete payload
-    while body.len() < body_size {
-        let mut buf: Vec<u8> = vec![0; body_size - body.len()];
-        let l = stream.read(&mut buf)?;
-
-        body.extend(&buf[0..l]);
-        if body.len() < body_size {
-            trace!(
-                "Incomplete message body waiting for the rest... ({}/{})",
-                body.len(),
-                body_size,
-            );
-            thread::sleep(Duration::from_millis(READ_MESSAGE_TIME_MS));
-        }
-    }
+    let mut body = vec![0u8; body_size];
+    let _ = tokio::time::timeout(Duration::from_secs(30), stream.read_exact(&mut body)).await?;
 
     assert_eq!(body.len(), body_size);
 
-    let uncrypted_body = parse_body(&body, ingress_mac, ingress_aes, next_size);
-
-    Ok(uncrypted_body)
+    Ok(parse_body(&body, ingress_mac, ingress_aes, next_size))
 }
+
 pub fn calculate_tx_addr(sender: &Vec<u8>, nonce: &u32) -> Vec<u8> {
     let mut rlp_encoded = RlpStream::new();
     rlp_encoded.begin_unbounded_list();
@@ -429,32 +411,29 @@ pub fn open_exec_sql_file(network_arg: &String, postgres_client: &mut Client) {
     postgres_client.batch_execute(&contents).unwrap();
 }
 
-pub fn send_eip8_auth_message(
+pub async fn send_eip8_auth_message(
     msg: &Vec<u8>,
-    stream: &mut std::net::TcpStream,
+    stream: &mut tokio::net::TcpStream,
 ) -> Result<(), Box<dyn error::Error>> {
-    stream.write(&msg)?;
-    stream.flush()?;
-
+    stream.write_all(msg).await?;
     Ok(())
 }
 
-pub fn read_ack_message(
-    stream: &mut std::net::TcpStream,
+pub async fn read_ack_message(
+    stream: &mut tokio::net::TcpStream,
 ) -> Result<(Vec<u8>, Vec<u8>), Box<dyn error::Error>> {
     let mut buf = [0u8; 2];
-    let _size = stream.read_exact(&mut buf)?;
+    stream.read_exact(&mut buf).await?;
 
-    let size_expected = buf.as_slice().read_u16::<BigEndian>().unwrap() as usize;
-    let shared_mac_data = &buf[0..2];
+    let size_expected = BigEndian::read_u16(&buf) as usize;
+    let shared_mac_data = buf[0..2].to_vec();
 
-    let mut payload = vec![0u8; size_expected.into()];
-    let size = stream.read(&mut payload)?;
+    let mut payload = vec![0u8; size_expected];
+    stream.read_exact(&mut payload).await?;
 
-    // TODO: better handle this to return an error and have a timeout
-    assert_eq!(size, size_expected);
+    assert_eq!(payload.len(), size_expected);
 
-    Ok((payload, shared_mac_data.to_vec()))
+    Ok((payload, shared_mac_data))
 }
 
 pub fn handle_ack_message(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -343,22 +343,18 @@ pub fn create_body(
 
 pub async fn send_message(
     msg: Vec<u8>,
-    stream: &Arc<tokio::sync::Mutex<tokio::net::TcpStream>>,
-    egress_mac: &Arc<Mutex<mac::MAC>>,
-    egress_aes: &Arc<Mutex<Aes256Ctr64BE>>,
-) -> Result<(), Box<dyn error::Error>> {
+    stream: &mut tokio::net::TcpStream,
+    egress_mac: &mut mac::MAC,
+    egress_aes: &mut Aes256Ctr64BE,
+) -> Result<(), Box<dyn error::Error + Send + Sync>> {
     // Compute header and body while holding the std::sync guards (not Send),
     // then drop them before any .await point.
     let (header, body) = {
-        let mut egress_aes = egress_aes.lock().unwrap();
-        let mut egress_mac = egress_mac.lock().unwrap();
         let header = create_header(msg.len(), egress_mac.borrow_mut(), egress_aes.borrow_mut());
         let body = create_body(msg, egress_mac.borrow_mut(), egress_aes.borrow_mut());
         (header, body)
     };
 
-    let mut guard = stream.lock().await;
-    let stream = &mut *guard;
     stream.write_all(&header).await?;
     stream.write_all(&body).await?;
 
@@ -366,13 +362,10 @@ pub async fn send_message(
 }
 
 pub async fn read_message(
-    stream: &Arc<tokio::sync::Mutex<tokio::net::TcpStream>>,
+    stream: &mut tokio::net::TcpStream,
     ingress_mac: &mut mac::MAC,
     ingress_aes: &mut Aes256Ctr64BE,
-) -> Result<Vec<u8>, Box<dyn error::Error>> {
-    let mut guard = stream.lock().await;
-    let stream = &mut *guard;
-
+) -> Result<Vec<u8>, Box<dyn error::Error + Send + Sync>> {
     let mut buf = [0u8; 32];
     let _ = tokio::time::timeout(Duration::from_secs(30), stream.read_exact(&mut buf)).await?;
 
@@ -414,22 +407,22 @@ pub fn open_exec_sql_file(network_arg: &String, postgres_client: &mut Client) {
 pub async fn send_eip8_auth_message(
     msg: &Vec<u8>,
     stream: &mut tokio::net::TcpStream,
-) -> Result<(), Box<dyn error::Error>> {
+) -> Result<(), Box<dyn error::Error + Send + Sync>> {
     stream.write_all(msg).await?;
     Ok(())
 }
 
 pub async fn read_ack_message(
     stream: &mut tokio::net::TcpStream,
-) -> Result<(Vec<u8>, Vec<u8>), Box<dyn error::Error>> {
+) -> Result<(Vec<u8>, Vec<u8>), Box<dyn error::Error + Send + Sync>> {
     let mut buf = [0u8; 2];
-    stream.read_exact(&mut buf).await?;
+    tokio::time::timeout(Duration::from_secs(30), stream.read_exact(&mut buf)).await??;
 
     let size_expected = BigEndian::read_u16(&buf) as usize;
     let shared_mac_data = buf[0..2].to_vec();
 
     let mut payload = vec![0u8; size_expected];
-    stream.read_exact(&mut payload).await?;
+    tokio::time::timeout(Duration::from_secs(30), stream.read_exact(&mut payload)).await??;
 
     assert_eq!(payload.len(), size_expected);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,8 +8,6 @@ use rlp::RlpStream;
 use sha3::{Digest, Keccak256};
 use std::borrow::BorrowMut;
 use std::error;
-use std::sync::Arc;
-use std::sync::Mutex;
 use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -365,17 +365,13 @@ pub async fn read_message(
     ingress_aes: &mut Aes256Ctr64BE,
 ) -> Result<Vec<u8>, Box<dyn error::Error + Send + Sync>> {
     let mut buf = [0u8; 32];
-    let _ = tokio::time::timeout(Duration::from_secs(30), stream.read_exact(&mut buf)).await?;
-
-    assert_eq!(buf.len(), 32);
+    tokio::time::timeout(Duration::from_secs(30), stream.read_exact(&mut buf)).await??;
 
     let next_size = parse_header(&buf.to_vec(), ingress_mac, ingress_aes);
     let body_size = get_body_len(next_size);
 
     let mut body = vec![0u8; body_size];
-    let _ = tokio::time::timeout(Duration::from_secs(30), stream.read_exact(&mut body)).await?;
-
-    assert_eq!(body.len(), body_size);
+    tokio::time::timeout(Duration::from_secs(30), stream.read_exact(&mut body)).await??;
 
     Ok(parse_body(&body, ingress_mac, ingress_aes, next_size))
 }


### PR DESCRIPTION
In this PR, we add support for managing and connecting to multiple peers. When syncing we speed up the process by asking for batch in concurrent tasks.

We also try to best manage keeping in syncing with new incoming blocks and re-org issue. 