### PR TITLE
perf: avoid heap allocation when parsing incoming eth messages

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -214,9 +214,9 @@ pub fn create_empty_block_headers_message(req_id: &usize) -> Vec<u8> {
     return [code.to_vec(), payload_compressed].concat();
 }
 
-pub fn parse_block_headers(payload: Vec<u8>) -> Vec<Block> {
+pub fn parse_block_headers(payload: &[u8]) -> Vec<Block> {
     let mut dec = snap::raw::Decoder::new();
-    let message = dec.decompress_vec(&payload).unwrap();
+    let message = dec.decompress_vec(payload).unwrap();
 
     let r = rlp::Rlp::new(&message);
     assert!(r.is_list());
@@ -284,11 +284,9 @@ pub fn create_get_receipts_message(hashes: &Vec<Vec<u8>>) -> Vec<u8> {
     return [code.to_vec(), payload_compressed].concat();
 }
 
-pub fn parse_block_bodies(
-    payload: Vec<u8>,
-) -> Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> {
+pub fn parse_block_bodies(payload: &[u8]) -> Vec<(Vec<Transaction>, Vec<Block>, Vec<Withdrawal>)> {
     let mut dec = snap::raw::Decoder::new();
-    let message = dec.decompress_vec(&payload).unwrap();
+    let message = dec.decompress_vec(payload).unwrap();
 
     let r = rlp::Rlp::new(&message);
     assert!(r.is_list());
@@ -344,9 +342,9 @@ pub fn parse_block_bodies(
     return result;
 }
 
-pub fn parse_receipts(payload: Vec<u8>) -> Vec<Vec<Receipt>> {
+pub fn parse_receipts(payload: &[u8]) -> Vec<Vec<Receipt>> {
     let mut dec = snap::raw::Decoder::new();
-    let message = dec.decompress_vec(&payload).unwrap();
+    let message = dec.decompress_vec(payload).unwrap();
 
     let r = rlp::Rlp::new(&message);
     assert!(r.is_list());

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,7 @@ fn main() {
                         None => continue,
                     };
 
-                    let headers = eth::parse_block_headers(headers_body[1..].to_vec());
+                    let headers = eth::parse_block_headers(&headers_body[1..]);
                     if headers.is_empty() {
                         warn!("No block headers received");
                         pool.push_back(conn);
@@ -364,7 +364,7 @@ fn main() {
                             match conn.rx_tcp.recv().await {
                                 Some(body) if body[0].saturating_sub(16) == 6 => {
                                     transactions
-                                        .extend(eth::parse_block_bodies(body[1..].to_vec()));
+                                        .extend(eth::parse_block_bodies(&body[1..]));
                                     break;
                                 }
                                 Some(_) => continue,
@@ -396,7 +396,7 @@ fn main() {
                             loop {
                                 match conn.rx_tcp.recv().await {
                                     Some(body) if body[0].saturating_sub(16) == 16 => {
-                                        receipts.extend(eth::parse_receipts(body[1..].to_vec()));
+                                        receipts.extend(eth::parse_receipts(&body[1..]));
                                         break;
                                     }
                                     Some(_) => continue,
@@ -489,7 +489,7 @@ fn main() {
                         None => continue,
                     };
 
-                    let headers = eth::parse_block_headers(headers_body[1..].to_vec());
+                    let headers = eth::parse_block_headers(&headers_body[1..]);
 
                     // Empty response means the peer doesn't recognise current_hash
                     // as canonical — assume re-org and roll back one block.
@@ -620,7 +620,7 @@ fn main() {
                     loop {
                         match conn.rx_tcp.recv().await {
                             Some(body) if body[0].saturating_sub(16) == 6 => {
-                                transactions.extend(eth::parse_block_bodies(body[1..].to_vec()));
+                                transactions.extend(eth::parse_block_bodies(&body[1..]));
                                 break;
                             }
                             Some(_) => continue,
@@ -648,7 +648,7 @@ fn main() {
                         loop {
                             match conn.rx_tcp.recv().await {
                                 Some(body) if body[0].saturating_sub(16) == 16 => {
-                                    receipts.extend(eth::parse_receipts(body[1..].to_vec()));
+                                    receipts.extend(eth::parse_receipts(&body[1..]));
                                     break;
                                 }
                                 Some(_) => continue,


### PR DESCRIPTION
parse_block_headers, parse_block_bodies, and parse_receipts now accept &[u8] instead of Vec<u8>, eliminating a full copy of each received message (potentially several MB per batch) before the snap decompression step. Call sites updated to pass slices directly.